### PR TITLE
Ecs create server group

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/AbstractECSDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/AbstractECSDescription.java
@@ -8,5 +8,5 @@ abstract class AbstractECSDescription extends AbstractAmazonCredentialsDescripti
   String application;
   String region;
   String stack;
-  String detail;
+  String freeFormDetails;
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
@@ -279,7 +279,7 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
       // TODO - handle errorinous versions.
     }
 
-    // TODO - Assuming that if present is always before detail.
+    // An assumption is made here: Stack always appears before detail in the server group name.
     if (splitResourceName.length >= 3) {
       serviceMetadata.setCloudStack(splitResourceName[1]);
     }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
@@ -185,7 +185,8 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
           .setEnvironmentVariables(containerDefinition.getEnvironment())
         ;
 
-        EcsServerGroup ecsServerGroup = generateServerGroup(awsRegion, metadata, instances, capacity);
+        EcsServerGroup ecsServerGroup = generateServerGroup(awsRegion, metadata, instances, capacity, creationTime,
+          clusterName, taskDefinition, vpcId, securityGroups);
 
         if (!clusterMap.containsKey(metadata.applicationName)) {
           EcsServerCluster spinnakerCluster = generateSpinnakerServerCluster(credentials, metadata, loadBalancers, ecsServerGroup);


### PR DESCRIPTION
Mainly:
* Detail being picked up and appended to the service name.
* clusterMap properly adds ECS clusters and server groups. ECS cluster's name is now the server group name without the version. ECS server groups now have a create time. getCluster now properly returns the correct ECS cluster with server groups.



