### PR TITLE
Fixes bug with lading task data

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCachingAgent.java
@@ -56,7 +56,7 @@ public class ContainerInstanceCachingAgent implements CachingAgent {
     for (CacheData cluster : clusters) {
       String nextToken = null;
       do {
-        ListContainerInstancesRequest listContainerInstancesRequest = new ListContainerInstancesRequest().withCluster((String) cluster.getAttributes().get("name"));
+        ListContainerInstancesRequest listContainerInstancesRequest = new ListContainerInstancesRequest().withCluster((String) cluster.getAttributes().get("clusterName"));
         if (nextToken != null) {
           listContainerInstancesRequest.setNextToken(nextToken);
         }
@@ -65,7 +65,7 @@ public class ContainerInstanceCachingAgent implements CachingAgent {
         List<String> containerInstanceArns = listContainerInstancesResult.getContainerInstanceArns();
 
         List<ContainerInstance> containerInstances = ecs.describeContainerInstances(new DescribeContainerInstancesRequest()
-          .withCluster((String) cluster.getAttributes().get("name")).withContainerInstances(containerInstanceArns)).getContainerInstances();
+          .withCluster((String) cluster.getAttributes().get("clusterName")).withContainerInstances(containerInstanceArns)).getContainerInstances();
 
         for (ContainerInstance containerInstance : containerInstances) {
           Map<String, Object> attributes = new HashMap<>();

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCachingAgent.java
@@ -57,13 +57,13 @@ public class ServiceCachingAgent implements CachingAgent {
     for (CacheData cluster : clusters) {
       String nextToken = null;
       do {
-        ListServicesRequest listServicesRequest = new ListServicesRequest().withCluster((String) cluster.getAttributes().get("name"));
+        ListServicesRequest listServicesRequest = new ListServicesRequest().withCluster((String) cluster.getAttributes().get("clusterName"));
         if (nextToken != null) {
           listServicesRequest.setNextToken(nextToken);
         }
         ListServicesResult listServicesResult = ecs.listServices(listServicesRequest);
         List<String> serviceArns = listServicesResult.getServiceArns();
-        List<Service> services = ecs.describeServices(new DescribeServicesRequest().withCluster((String) cluster.getAttributes().get("name")).withServices(serviceArns)).getServices();
+        List<Service> services = ecs.describeServices(new DescribeServicesRequest().withCluster((String) cluster.getAttributes().get("clusterName")).withServices(serviceArns)).getServices();
 
         for (Service service : services) {
           Map<String, Object> attributes = new HashMap<>();

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
@@ -62,13 +62,13 @@ public class TaskCachingAgent implements CachingAgent {
     for (CacheData cluster : clusters) {
       String nextToken = null;
       do {
-        ListTasksRequest listTasksRequest = new ListTasksRequest().withCluster((String) cluster.getAttributes().get("name"));
+        ListTasksRequest listTasksRequest = new ListTasksRequest().withCluster((String) cluster.getAttributes().get("clusterName"));
         if (nextToken != null) {
           listTasksRequest.setNextToken(nextToken);
         }
         ListTasksResult listTasksResult = ecs.listTasks(listTasksRequest);
         List<String> taskArns = listTasksResult.getTaskArns();
-        List<Task> tasks = ecs.describeTasks(new DescribeTasksRequest().withCluster((String) cluster.getAttributes().get("name")).withTasks(taskArns)).getTasks();
+        List<Task> tasks = ecs.describeTasks(new DescribeTasksRequest().withCluster((String) cluster.getAttributes().get("clusterName")).withTasks(taskArns)).getTasks();
 
         for (Task task : tasks) {
           Map<String, Object> attributes = new HashMap<>();


### PR DESCRIPTION
The "name" attribute does not exist. 

Resulting in the cluster name to be null and the following error in the logs:

```2017-09-29 21:06:06.198  WARN 51613 --- [cutionAction-20] c.n.s.c.cache.LoggingInstrumentation     : com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider:TaskCachingAgent completed

com.amazonaws.services.ecs.model.ClusterNotFoundException: Cluster not found. (Service: AmazonECS; Status Code: 400; Error Code: ClusterNotFoundException; Request ID: 3eaa4021-a549-11e7-ad0b-1ba3766ff9c6)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1587) ~[aws-java-sdk-core-1.11.173.jar:na]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1257) ~[aws-java-sdk-core-1.11.173.jar:na]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1029) ~[aws-java-sdk-core-1.11.173.jar:na]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:741) ~[aws-java-sdk-core-1.11.173.jar:na]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:715) ~[aws-java-sdk-core-1.11.173.jar:na]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:697) ~[aws-java-sdk-core-1.11.173.jar:na]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:665) ~[aws-java-sdk-core-1.11.173.jar:na]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:647) ~[aws-java-sdk-core-1.11.173.jar:na]
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:511) ~[aws-java-sdk-core-1.11.173.jar:na]
	at com.amazonaws.services.ecs.AmazonECSClient.doInvoke(AmazonECSClient.java:2609) ~[aws-java-sdk-ecs-1.11.173.jar:na]
	at com.amazonaws.services.ecs.AmazonECSClient.invoke(AmazonECSClient.java:2585) ~[aws-java-sdk-ecs-1.11.173.jar:na]
	at com.amazonaws.services.ecs.AmazonECSClient.executeListTasks(AmazonECSClient.java:1663) ~[aws-java-sdk-ecs-1.11.173.jar:na]
	at com.amazonaws.services.ecs.AmazonECSClient.listTasks(AmazonECSClient.java:1639) ~[aws-java-sdk-ecs-1.11.173.jar:na]
	at com.netflix.spinnaker.clouddriver.ecs.provider.agent.TaskCachingAgent.loadData(TaskCachingAgent.java:69) ~[classes/:na]
	at com.netflix.spinnaker.cats.agent.CachingAgent$CacheExecution.executeAgentWithoutStore(CachingAgent.java:66) ~[classes/:na]
	at com.netflix.spinnaker.cats.agent.CachingAgent$CacheExecution.executeAgent(CachingAgent.java:59) ~[classes/:na]
	at com.netflix.spinnaker.cats.redis.cluster.ClusteredAgentScheduler$AgentExecutionAction.execute(ClusteredAgentScheduler.java:205) ~[classes/:na]
	at com.netflix.spinnaker.cats.redis.cluster.ClusteredAgentScheduler$AgentJob.run(ClusteredAgentScheduler.java:179) ~[classes/:na]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[na:1.8.0_144]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[na:1.8.0_144]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[na:1.8.0_144]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_144]
	at java.lang.Thread.run(Thread.java:748) [na:1.8.0_144]
```