### PR TITLE
feat(provider/ecs) ECS Uses AutoScaling groups for size and resizing server groups

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
@@ -20,6 +20,8 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.handlers.RequestHandler2;
 import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.retry.RetryPolicy;
+import com.amazonaws.services.applicationautoscaling.AWSApplicationAutoScaling;
+import com.amazonaws.services.applicationautoscaling.AWSApplicationAutoScalingClientBuilder;
 import com.amazonaws.services.autoscaling.AmazonAutoScaling;
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClientBuilder;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
@@ -49,9 +51,9 @@ import com.amazonaws.services.sns.AmazonSNSClientBuilder;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.awsobjectmapper.AmazonObjectMapperConfigurer;
 import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spectator.api.Registry;
-import com.netflix.awsobjectmapper.AmazonObjectMapperConfigurer;
 import com.netflix.spinnaker.clouddriver.aws.security.sdkclient.AmazonClientInvocationHandler;
 import com.netflix.spinnaker.clouddriver.aws.security.sdkclient.AwsSdkClientSupplier;
 import com.netflix.spinnaker.clouddriver.aws.security.sdkclient.ProxyHandlerBuilder;
@@ -321,6 +323,10 @@ public class AmazonClientProvider {
 
   public AmazonAutoScaling getAutoScaling(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
     return awsSdkClientSupplier.getClient(AmazonAutoScalingClientBuilder.class, AmazonAutoScaling.class, accountName, awsCredentialsProvider, region);
+  }
+
+  public AWSApplicationAutoScaling getAmazonApplicationAutoScaling(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
+    return awsSdkClientSupplier.getClient(AWSApplicationAutoScalingClientBuilder.class, AWSApplicationAutoScaling.class, accountName, awsCredentialsProvider, region);
   }
 
   public AmazonRoute53 getAmazonRoute53(NetflixAmazonCredentials amazonCredentials, String region) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
@@ -325,10 +325,6 @@ public class AmazonClientProvider {
     return awsSdkClientSupplier.getClient(AmazonAutoScalingClientBuilder.class, AmazonAutoScaling.class, accountName, awsCredentialsProvider, region);
   }
 
-  public AWSApplicationAutoScaling getAmazonApplicationAutoScaling(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
-    return awsSdkClientSupplier.getClient(AWSApplicationAutoScalingClientBuilder.class, AWSApplicationAutoScaling.class, accountName, awsCredentialsProvider, region);
-  }
-
   public AmazonRoute53 getAmazonRoute53(NetflixAmazonCredentials amazonCredentials, String region) {
     return getAmazonRoute53(amazonCredentials, region, false);
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
@@ -429,4 +429,8 @@ public class AmazonClientProvider {
   public AmazonIdentityManagement getAmazonIdentityManagement(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
     return awsSdkClientSupplier.getClient(AmazonIdentityManagementClientBuilder.class, AmazonIdentityManagement.class, accountName, awsCredentialsProvider, region);
   }
+
+  public AWSApplicationAutoScaling getAmazonApplicationAutoScaling(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
+    return awsSdkClientSupplier.getClient(AWSApplicationAutoScalingClientBuilder.class, AWSApplicationAutoScaling.class, accountName, awsCredentialsProvider, region);
+  }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
@@ -1,5 +1,10 @@
 package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.applicationautoscaling.AWSApplicationAutoScaling;
+import com.amazonaws.services.applicationautoscaling.model.RegisterScalableTargetRequest;
+import com.amazonaws.services.applicationautoscaling.model.ScalableDimension;
+import com.amazonaws.services.applicationautoscaling.model.ServiceNamespace;
 import com.amazonaws.services.ecs.AmazonECS;
 import com.amazonaws.services.ecs.model.ContainerDefinition;
 import com.amazonaws.services.ecs.model.CreateServiceRequest;
@@ -22,7 +27,6 @@ import com.netflix.spinnaker.clouddriver.ecs.deploy.description.CreateServerGrou
 import com.netflix.spinnaker.clouddriver.ecs.services.ContainerInformationService;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Arrays;
@@ -54,88 +58,185 @@ public class CreateServerGroupAtomicOperation implements AtomicOperation<Deploym
 
   @Override
   public DeploymentResult operate(List priorOutputs) {
-    getTask().updateStatus(BASE_PHASE, "Initializing Create Amazon ECS Server Group Operation...");
-    AmazonCredentials credentials = (AmazonCredentials) accountCredentialsProvider.getCredentials(description.getCredentialAccount());
-    String versionString = inferServergroupVersion();
+    updateTaskStatus("Initializing Create Amazon ECS Server Group Operation...");
 
-    String familyName = getFamilyName();
-    String serviceName = familyName + "-" + versionString;
+    TaskDefinition taskDefinition = registerTaskDefinition();
+    createService(taskDefinition);
+    createAutoScalingGroup();
 
-    if (description.getAvailabilityZones().size() != 1) {
-      throw new Error(String.format("You must specify exactly 1 region to be used.  You specified %s region(s)"));
-    }
+    return getDeploymentResult();
+  }
 
-    String region = description.getAvailabilityZones().keySet().iterator().next();
-    AmazonECS ecs = amazonClientProvider.getAmazonEcs(description.getCredentialAccount(), credentials.getCredentialsProvider(), region);
-    TaskDefinition taskDefinition = registerTaskDefinition(ecs, versionString);
+  private TaskDefinition registerTaskDefinition() {
+    AmazonECS ecs = getAmazonEcsClient();
+    String serverGroupVersion = inferServerGroupVersion();
+
+    Collection<KeyValuePair> containerEnvironment = new LinkedList<>();
+    containerEnvironment.add(new KeyValuePair().withName("SERVER_GROUP").withValue(serverGroupVersion));
+    containerEnvironment.add(new KeyValuePair().withName("CLOUD_STACK").withValue(description.getStack()));
+    containerEnvironment.add(new KeyValuePair().withName("CLOUD_DETAIL").withValue(description.getFreeFormDetails()));
+
+    PortMapping portMapping = new PortMapping()
+      .withHostPort(0)
+      .withContainerPort(description.getContainerPort())
+      .withProtocol(description.getPortProtocol() != null ? description.getPortProtocol() : "tcp");
+
+    Collection<PortMapping> portMappings = new LinkedList<>();
+    portMappings.add(portMapping);
+
+    ContainerDefinition containerDefinition = new ContainerDefinition()
+      .withName(serverGroupVersion)
+      .withEnvironment(containerEnvironment)
+      .withPortMappings(portMappings)
+      .withCpu(description.getComputeUnits())
+      .withMemoryReservation(description.getReservedMemory())
+      .withImage(description.getDockerImageAddress());
+
+    Collection<ContainerDefinition> containerDefinitions = new LinkedList<>();
+    containerDefinitions.add(containerDefinition);
+
+    RegisterTaskDefinitionRequest request = new RegisterTaskDefinitionRequest()
+      .withContainerDefinitions(containerDefinitions)
+      .withFamily(getFamilyName());
+
+    updateTaskStatus("Creating Amazon ECS Task Definition...");
+    RegisterTaskDefinitionResult registerTaskDefinitionResult = ecs.registerTaskDefinition(request);
+    updateTaskStatus("Done creating Amazon ECS Task Definition...");
+
+    return registerTaskDefinitionResult.getTaskDefinition();
+  }
+
+  private void createService(TaskDefinition taskDefinition) {
+    AmazonECS ecs = getAmazonEcsClient();
+    String serviceName = getServiceName();
+    Collection<LoadBalancer> loadBalancers = new LinkedList<>();
+    loadBalancers.add(getLoadBalancer());
+
+    Integer desiredCapacity = getDesiredCapacity();
+    String taskDefinitionArn = taskDefinition.getTaskDefinitionArn();
+
+    DeploymentConfiguration deploymentConfiguration = new DeploymentConfiguration()
+      .withMinimumHealthyPercent(50)
+      .withMaximumPercent(100);
+
+    CreateServiceRequest request = new CreateServiceRequest()
+      .withServiceName(serviceName)
+      .withDesiredCount(desiredCapacity != null ? desiredCapacity : 1)
+      .withCluster(description.getEcsClusterName())
+      .withRole(description.getIamRole())
+      .withLoadBalancers(loadBalancers)
+      .withTaskDefinition(taskDefinitionArn)
+      .withDeploymentConfiguration(deploymentConfiguration);
+
+    updateTaskStatus(String.format("Creating %s of %s with %s for %s.",
+      desiredCapacity, serviceName, taskDefinitionArn, description.getCredentialAccount()));
+
+    ecs.createService(request);
+
+    updateTaskStatus(String.format("Done creating %s of %s with %s for %s.",
+      desiredCapacity, serviceName, taskDefinitionArn, description.getCredentialAccount()));
+  }
+
+  private void createAutoScalingGroup() {
+    AWSApplicationAutoScaling autoScalingClient = getAmazonApplicationAutoScalingClient();
+    RegisterScalableTargetRequest request = new RegisterScalableTargetRequest()
+      .withServiceNamespace(ServiceNamespace.Ecs)
+      .withScalableDimension(ScalableDimension.EcsServiceDesiredCount)
+      .withResourceId(String.format("service/%s/%s", description.getEcsClusterName(), getServiceName()))
+      .withMinCapacity(0)
+      .withMaxCapacity(getDesiredCapacity());
+
+    updateTaskStatus("Creating Amazon Application Auto Scaling Scalable Target Definition...");
+    autoScalingClient.registerScalableTarget(request);
+    updateTaskStatus("Done creating Amazon Application Auto Scaling Scalable Target Definition...");
+  }
+
+  private DeploymentResult getDeploymentResult() {
+    Map<String, String> namesByRegion = new HashMap<>();
+    namesByRegion.put(getRegion(), getServiceName());
+
+    DeploymentResult result = new DeploymentResult();
+    result.setServerGroupNames(Arrays.asList(getServerGroupName()));
+    result.setServerGroupNameByRegion(namesByRegion);
+    return result;
+  }
+
+  private LoadBalancer getLoadBalancer() {
+    AmazonCredentials credentials = getCredentials();
+    String region = getRegion();
+    String versionString = inferServerGroupVersion();
 
     LoadBalancer loadBalancer = new LoadBalancer();
     loadBalancer.setContainerName(versionString);
     loadBalancer.setContainerPort(description.getContainerPort());
 
     if (description.getTargetGroups().size() == 1) {
-      AmazonElasticLoadBalancing loadBalancingV2 = amazonClientProvider.getAmazonElasticLoadBalancingV2(description.getCredentialAccount(), credentials.getCredentialsProvider(), region);
+      AmazonElasticLoadBalancing loadBalancingV2 = amazonClientProvider.getAmazonElasticLoadBalancingV2(
+        description.getCredentialAccount(),
+        credentials.getCredentialsProvider(),
+        region);
       String targetGroupName = description.getTargetGroups().get(0);  // TODO - make target group a single value field in Deck instead of an array here
-      DescribeTargetGroupsResult describeTargetGroupsResult = loadBalancingV2.describeTargetGroups(new DescribeTargetGroupsRequest().withNames(targetGroupName));
+      DescribeTargetGroupsRequest request = new DescribeTargetGroupsRequest().withNames(targetGroupName);
+      DescribeTargetGroupsResult describeTargetGroupsResult = loadBalancingV2.describeTargetGroups(request);
       loadBalancer.setTargetGroupArn(describeTargetGroupsResult.getTargetGroups().get(0).getTargetGroupArn());
     }
-
-    Collection<LoadBalancer> loadBalancers = new LinkedList<>();
-    loadBalancers.add(loadBalancer);
-
-    CreateServiceRequest request = new CreateServiceRequest();
-    request.setServiceName(serviceName);
-    request.setDesiredCount(description.getCapacity().getDesired() != null ? description.getCapacity().getDesired() : 1);
-    request.setCluster(description.getEcsClusterName());
-    request.setRole(description.getIamRole());
-    request.setLoadBalancers(loadBalancers);
-    request.setTaskDefinition(taskDefinition.getTaskDefinitionArn());
-    request.setDeploymentConfiguration(new DeploymentConfiguration().withMinimumHealthyPercent(50).withMaximumPercent(100));
-
-
-    getTask().updateStatus(BASE_PHASE, "Creating " + description.getCapacity().getDesired() + " of " + serviceName +
-      " with " + taskDefinition.getTaskDefinitionArn() + " for " + description.getCredentialAccount() + ".");
-    ecs.createService(request);
-    getTask().updateStatus(BASE_PHASE, "Done creating " + description.getCapacity().getDesired() + " of " + serviceName +
-      " with " + taskDefinition.getTaskDefinitionArn() + " for " + description.getCredentialAccount() + ".");
-
-    String serverGroupName = region + ":" + serviceName;  // See in Orca MonitorKatoTask#getServerGroupNames for a reason for this
-
-    DeploymentResult result = new DeploymentResult();
-    result.setServerGroupNames(Arrays.asList(serverGroupName));
-    Map<String, String> namesByRegion = new HashMap<>();
-    namesByRegion.put(region, serviceName);
-
-    result.setServerGroupNameByRegion(namesByRegion);
-
-    return result;
+    return loadBalancer;
   }
 
-  private String inferServergroupVersion() {
+  private AWSApplicationAutoScaling getAmazonApplicationAutoScalingClient() {
+    AWSCredentialsProvider credentialsProvider = getCredentials().getCredentialsProvider();
+    String region = getRegion();
+    String credentialAccount = description.getCredentialAccount();
+
+    return amazonClientProvider.getAmazonApplicationAutoScaling(credentialAccount, credentialsProvider, region);
+  }
+
+  private AmazonECS getAmazonEcsClient() {
+    AWSCredentialsProvider credentialsProvider = getCredentials().getCredentialsProvider();
+    String region = getRegion();
+    String credentialAccount = description.getCredentialAccount();
+
+    return amazonClientProvider.getAmazonEcs(credentialAccount, credentialsProvider, region);
+  }
+
+  private String getServerGroupName() {
+    // See in Orca MonitorKatoTask#getServerGroupNames for a reason for this
+    return getRegion() + ":" + getServiceName();
+  }
+
+  private void updateTaskStatus(String status) {
+    getTask().updateStatus(BASE_PHASE, status);
+  }
+
+  private AmazonCredentials getCredentials() {
+    return (AmazonCredentials) accountCredentialsProvider.getCredentials(description.getCredentialAccount());
+  }
+
+  private Integer getDesiredCapacity() {
+    return description.getCapacity().getDesired();
+  }
+
+  private String getServiceName() {
+    String familyName = getFamilyName();
+    String versionString = inferServerGroupVersion();
+    return familyName + "-" + versionString;
+  }
+
+  private String getRegion() {
+    hasValidRegion();
+    return description.getAvailabilityZones().keySet().iterator().next();
+  }
+
+  private void hasValidRegion() {
+    if (description.getAvailabilityZones().size() != 1) {
+      String message = "You must specify exactly 1 region to be used.  You specified %s region(s)";
+      throw new Error(String.format(message, description.getAvailabilityZones().size()));
+    }
+  }
+
+  private String inferServerGroupVersion() {
     int version = containerInformationService.getLatestServiceVersion(description.getEcsClusterName(), getFamilyName(), description.getCredentialAccount(), description.getRegion());
     return String.format("v%04d", (version+ 1));
-
-  }
-
-  private TaskDefinition registerTaskDefinition(AmazonECS ecs, String versionString) {
-    Collection<KeyValuePair> containerEnvironment = new LinkedList<>();
-    containerEnvironment.add(new KeyValuePair().withName("SERVER_GROUP").withValue(versionString));
-    containerEnvironment.add(new KeyValuePair().withName("CLOUD_STACK").withValue(description.getStack()));
-    containerEnvironment.add(new KeyValuePair().withName("CLOUD_DETAIL").withValue(description.getFreeFormDetails()));
-
-    Collection<PortMapping> portMappings = new LinkedList<>();
-    portMappings.add(new PortMapping().withHostPort(0).withContainerPort(description.getContainerPort())
-      .withProtocol(description.getPortProtocol() != null ? description.getPortProtocol() : "tcp"));
-
-    Collection<ContainerDefinition> containerDefinitions = new LinkedList<>();
-    containerDefinitions.add(new ContainerDefinition().withName(versionString).withEnvironment(containerEnvironment).withPortMappings(portMappings)
-      .withCpu(description.getComputeUnits()).withMemoryReservation(description.getReservedMemory()).withImage(description.getDockerImageAddress()));
-
-    getTask().updateStatus(BASE_PHASE, "Creating Amazon ECS Task Definition...");
-    RegisterTaskDefinitionResult registerTaskDefinitionResult = ecs.registerTaskDefinition(new RegisterTaskDefinitionRequest()
-      .withContainerDefinitions(containerDefinitions).withFamily(getFamilyName()));
-    getTask().updateStatus(BASE_PHASE, "Done creating Amazon ECS Task Definition...");
-    return registerTaskDefinitionResult.getTaskDefinition();
   }
 
   private String getFamilyName() {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DisableServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DisableServiceAtomicOperation.java
@@ -64,8 +64,7 @@ public class DisableServiceAtomicOperation implements AtomicOperation<Void> {
 
     String service = description.getServerGroupName();
     String account = description.getCredentialAccount();
-    String region = description.getRegion();
-    String cluster = containerInformationService.getClusterName(service, account, region);
+    String cluster = getCluster(service, account);
 
     updateTaskStatus(String.format("Disabling %s service for %s.", service, account));
     UpdateServiceRequest request = new UpdateServiceRequest()
@@ -74,6 +73,11 @@ public class DisableServiceAtomicOperation implements AtomicOperation<Void> {
       .withDesiredCount(0);
     ecs.updateService(request);
     updateTaskStatus(String.format("Service %s disabled for %s.", service, account));
+  }
+
+  private String getCluster(String service, String account) {
+    String region = description.getRegion();
+    return containerInformationService.getClusterName(service, account, region);
   }
 
   private AmazonECS getAmazonEcsClient() {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/EnableServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/EnableServiceAtomicOperation.java
@@ -16,6 +16,13 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.applicationautoscaling.AWSApplicationAutoScaling;
+import com.amazonaws.services.applicationautoscaling.model.DescribeScalableTargetsRequest;
+import com.amazonaws.services.applicationautoscaling.model.DescribeScalableTargetsResult;
+import com.amazonaws.services.applicationautoscaling.model.ScalableDimension;
+import com.amazonaws.services.applicationautoscaling.model.ScalableTarget;
+import com.amazonaws.services.applicationautoscaling.model.ServiceNamespace;
 import com.amazonaws.services.ecs.AmazonECS;
 import com.amazonaws.services.ecs.model.UpdateServiceRequest;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
@@ -28,6 +35,7 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class EnableServiceAtomicOperation implements AtomicOperation<Void> {
@@ -52,16 +60,85 @@ public class EnableServiceAtomicOperation implements AtomicOperation<Void> {
 
   @Override
   public Void operate(List priorOutputs) {
-    getTask().updateStatus(BASE_PHASE, "Initializing Enable Amazon ECS Server Group Operation...");
-
-    AmazonCredentials credentials = (AmazonCredentials) accountCredentialsProvider.getCredentials(description.getCredentialAccount());
-    AmazonECS ecs = amazonClientProvider.getAmazonEcs(description.getCredentialAccount(), credentials.getCredentialsProvider(), description.getRegion());
-    String clusterName = containerInformationService.getClusterName(description.getServerGroupName(), description.getCredentialAccount(), description.getRegion());
-
-    getTask().updateStatus(BASE_PHASE, "Enabling " + description.getServerGroupName() + " service for " + description.getCredentialAccount() + ".");
-    ecs.updateService(new UpdateServiceRequest().withCluster(clusterName).withService(description.getServerGroupName()).withDesiredCount(1));
-    getTask().updateStatus(BASE_PHASE, "Service " + description.getServerGroupName() + " enabled for " + description.getCredentialAccount() + ".");
-
+    updateTaskStatus("Initializing Enable Amazon ECS Server Group Operation...");
+    enableService();
     return null;
+  }
+
+  private void enableService() {
+    AmazonECS ecsClient = getAmazonEcsClient();
+
+    String service = description.getServerGroupName();
+    String account = description.getCredentialAccount();
+    String cluster = containerInformationService.getClusterName(service, account, description.getRegion());
+
+    UpdateServiceRequest request = new UpdateServiceRequest()
+      .withCluster(cluster)
+      .withService(service)
+      .withDesiredCount(getMaxCapacity());
+
+    updateTaskStatus(String.format("Enabling %s service for %s.", service, account));
+    ecsClient.updateService(request);
+    updateTaskStatus(String.format("Service %s enabled for %s.", service, account));
+  }
+
+  private Integer getMaxCapacity() {
+    ScalableTarget target = getScalableTarget();
+    if (target != null) {
+      return target.getMaxCapacity();
+    }
+    return 1;
+  }
+
+  private ScalableTarget getScalableTarget() {
+    AWSApplicationAutoScaling appASClient = getAmazonApplicationAutoScalingClient();
+
+    String service = description.getServerGroupName();
+    String account = description.getCredentialAccount();
+    String cluster = containerInformationService.getClusterName(service, account, description.getRegion());
+
+    List<String> resourceIds = new ArrayList<>();
+    resourceIds.add(String.format("service/%s/%s", cluster, service));
+
+    DescribeScalableTargetsRequest request = new DescribeScalableTargetsRequest()
+      .withResourceIds(resourceIds)
+      .withScalableDimension(ScalableDimension.EcsServiceDesiredCount)
+      .withServiceNamespace(ServiceNamespace.Ecs);
+
+    DescribeScalableTargetsResult result = appASClient.describeScalableTargets(request);
+
+    if (result.getScalableTargets().isEmpty()) {
+      return null;
+    }
+
+    if (result.getScalableTargets().size() == 1) {
+      return result.getScalableTargets().get(0);
+    }
+
+    throw new Error("Multiple Scalable Targets found");
+  }
+
+  private AWSApplicationAutoScaling getAmazonApplicationAutoScalingClient() {
+    AWSCredentialsProvider credentialsProvider = getCredentials().getCredentialsProvider();
+    String region = description.getRegion();
+    String credentialAccount = description.getCredentialAccount();
+
+    return amazonClientProvider.getAmazonApplicationAutoScaling(credentialAccount, credentialsProvider, region);
+  }
+
+  private AmazonECS getAmazonEcsClient() {
+    AWSCredentialsProvider credentialsProvider = getCredentials().getCredentialsProvider();
+    String region = description.getRegion();
+    String credentialAccount = description.getCredentialAccount();
+
+    return amazonClientProvider.getAmazonEcs(credentialAccount, credentialsProvider, region);
+  }
+
+  private AmazonCredentials getCredentials() {
+    return (AmazonCredentials) accountCredentialsProvider.getCredentials(description.getCredentialAccount());
+  }
+
+  private void updateTaskStatus(String status) {
+    getTask().updateStatus(BASE_PHASE, status);
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/EnableServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/EnableServiceAtomicOperation.java
@@ -70,7 +70,7 @@ public class EnableServiceAtomicOperation implements AtomicOperation<Void> {
 
     String service = description.getServerGroupName();
     String account = description.getCredentialAccount();
-    String cluster = containerInformationService.getClusterName(service, account, description.getRegion());
+    String cluster = getCluster(service, account);
 
     UpdateServiceRequest request = new UpdateServiceRequest()
       .withCluster(cluster)
@@ -80,6 +80,10 @@ public class EnableServiceAtomicOperation implements AtomicOperation<Void> {
     updateTaskStatus(String.format("Enabling %s service for %s.", service, account));
     ecsClient.updateService(request);
     updateTaskStatus(String.format("Service %s enabled for %s.", service, account));
+  }
+
+  private String getCluster(String service, String account) {
+    return containerInformationService.getClusterName(service, account, description.getRegion());
   }
 
   private Integer getMaxCapacity() {
@@ -95,7 +99,7 @@ public class EnableServiceAtomicOperation implements AtomicOperation<Void> {
 
     String service = description.getServerGroupName();
     String account = description.getCredentialAccount();
-    String cluster = containerInformationService.getClusterName(service, account, description.getRegion());
+    String cluster = getCluster(service, account);
 
     List<String> resourceIds = new ArrayList<>();
     resourceIds.add(String.format("service/%s/%s", cluster, service));

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/EcsServerGroup.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/EcsServerGroup.java
@@ -56,7 +56,7 @@ public class EcsServerGroup implements ServerGroup {
 
   @Data
   @NoArgsConstructor
-  public class AutoScalingGroup {
+  public static class AutoScalingGroup {
     Integer minSize;
     Integer maxSize;
     Integer desiredCapacity;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/EcsServerGroup.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/EcsServerGroup.java
@@ -47,10 +47,19 @@ public class EcsServerGroup implements ServerGroup {
   String ecsCluster;
   TaskDefinition taskDefinition;
   String vpcId;
+  AutoScalingGroup asg;
 
   @Override
   public Boolean isDisabled() {
     return disabled;
+  }
+
+  @Data
+  @NoArgsConstructor
+  public class AutoScalingGroup {
+    Integer minSize;
+    Integer maxSize;
+    Integer desiredCapacity;
   }
 
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
@@ -238,14 +238,14 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
       .withResourceIds(resourceIds)
       .withScalableDimension(ScalableDimension.EcsServiceDesiredCount)
       .withServiceNamespace(ServiceNamespace.Ecs);
-    DescribeScalableTargetsResult result1 = appASClient.describeScalableTargets(request);
+    DescribeScalableTargetsResult result = appASClient.describeScalableTargets(request);
 
-    if (result1.getScalableTargets().isEmpty()) {
+    if (result.getScalableTargets().isEmpty()) {
       return null;
     }
 
-    if (result1.getScalableTargets().size() == 1) {
-      return result1.getScalableTargets().get(0);
+    if (result.getScalableTargets().size() == 1) {
+      return result.getScalableTargets().get(0);
     }
 
     throw new Error("Multiple Scalable Targets found");

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
@@ -261,6 +261,7 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
       .setTaskDefinition(taskDefinition)
       .setVpcId(vpcId)
       .setSecurityGroups(securityGroups)
+      .setAsg(new ApplicationAutoScalingGroup().setDesiredCapacity(1).setMaxSize(2).setMinSize(3))
       ;
   }
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
@@ -16,6 +16,13 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.provider.view;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.applicationautoscaling.AWSApplicationAutoScaling;
+import com.amazonaws.services.applicationautoscaling.model.DescribeScalableTargetsRequest;
+import com.amazonaws.services.applicationautoscaling.model.DescribeScalableTargetsResult;
+import com.amazonaws.services.applicationautoscaling.model.ScalableDimension;
+import com.amazonaws.services.applicationautoscaling.model.ScalableTarget;
+import com.amazonaws.services.applicationautoscaling.model.ServiceNamespace;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.model.GroupIdentifier;
@@ -58,6 +65,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -159,12 +167,20 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
 
         DescribeServicesResult describeServicesResult =
           amazonECS.describeServices(new DescribeServicesRequest().withCluster(clusterArn).withServices(serviceArn));
+        String clusterName = inferClusterNameFromClusterArn(describeServicesResult.getServices().get(0).getClusterArn());
+        ScalableTarget target = getScalableTarget(credentials, awsRegion, serviceArn, clusterName);
         ServerGroup.Capacity capacity = new ServerGroup.Capacity();
         capacity.setDesired(describeServicesResult.getServices().get(0).getDesiredCount());
-        capacity.setMin(describeServicesResult.getServices().get(0).getDesiredCount());  // TODO - perhaps we want to look at the % min and max for the service?
-        capacity.setMax(describeServicesResult.getServices().get(0).getDesiredCount());  // TODO - perhaps we want to look at the % min and max for the service?
+        if (target != null) {
+          capacity.setMin(target.getMinCapacity());
+          capacity.setMax(target.getMaxCapacity());
+        } else {
+          capacity.setMin(describeServicesResult.getServices().get(0).getDesiredCount());
+          capacity.setMax(describeServicesResult.getServices().get(0).getDesiredCount());
+        }
+
         long creationTime = describeServicesResult.getServices().get(0).getCreatedAt().getTime();
-        String clusterName = inferClusterNameFromClusterArn(describeServicesResult.getServices().get(0).getClusterArn());
+
 
         DescribeTaskDefinitionRequest taskDefinitionRequest = new DescribeTaskDefinitionRequest().withTaskDefinition(describeServicesResult.getServices().get(0).getTaskDefinition());
         DescribeTaskDefinitionResult taskDefinitionResult = amazonECS.describeTaskDefinition(taskDefinitionRequest);
@@ -186,10 +202,10 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
         ;
 
         EcsServerGroup ecsServerGroup = generateServerGroup(awsRegion, metadata, instances, capacity, creationTime,
-          clusterName, taskDefinition, vpcId, securityGroups);
+          clusterName, taskDefinition, vpcId, securityGroups, target);
 
         if (!clusterMap.containsKey(metadata.applicationName)) {
-          EcsServerCluster spinnakerCluster = generateSpinnakerServerCluster(credentials, metadata, loadBalancers, ecsServerGroup);
+          EcsServerCluster spinnakerCluster = generateSpinnakerServerCluster(credentials, loadBalancers, ecsServerGroup);
           clusterMap.put(metadata.applicationName, Sets.newHashSet(spinnakerCluster));
         } else {
           String escClusterName = removeVersion(ecsServerGroup.getName());
@@ -204,7 +220,7 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
           }
 
           if(!found){
-            EcsServerCluster spinnakerCluster = generateSpinnakerServerCluster(credentials, metadata, loadBalancers, ecsServerGroup);
+            EcsServerCluster spinnakerCluster = generateSpinnakerServerCluster(credentials, loadBalancers, ecsServerGroup);
             clusterMap.get(metadata.applicationName).add(spinnakerCluster);
           }
         }
@@ -212,6 +228,27 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
     }
 
     return clusterMap;
+  }
+
+  private ScalableTarget getScalableTarget(AmazonCredentials credentials, AmazonCredentials.AWSRegion awsRegion, String serviceArn, String clusterName) {
+    AWSApplicationAutoScaling appASClient = getAmazonApplicationAutoScalingClient(credentials, awsRegion);
+    List<String> resourceIds = new ArrayList<>();
+    resourceIds.add(String.format("service/%s/%s", clusterName, getServiceName(serviceArn)));
+    DescribeScalableTargetsRequest request = new DescribeScalableTargetsRequest()
+      .withResourceIds(resourceIds)
+      .withScalableDimension(ScalableDimension.EcsServiceDesiredCount)
+      .withServiceNamespace(ServiceNamespace.Ecs);
+    DescribeScalableTargetsResult result1 = appASClient.describeScalableTargets(request);
+
+    if (result1.getScalableTargets().isEmpty()) {
+      return null;
+    }
+
+    if (result1.getScalableTargets().size() == 1) {
+      return result1.getScalableTargets().get(0);
+    }
+
+    throw new Error("Multiple Scalable Targets found");
   }
 
   private Set<com.netflix.spinnaker.clouddriver.model.LoadBalancer> extractLoadBalancersData(
@@ -226,7 +263,6 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
   }
 
   private EcsServerCluster generateSpinnakerServerCluster(AmazonCredentials credentials,
-                                                          ServiceMetadata metadata,
                                                           Set<com.netflix.spinnaker.clouddriver.model.LoadBalancer> loadBalancers,
                                                           EcsServerGroup ecsServerGroup) {
     return new EcsServerCluster()
@@ -244,11 +280,12 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
                                              String ecsCluster,
                                              TaskDefinition taskDefinition,
                                              String vpcId,
-                                             Set<String> securityGroups) {
+                                             Set<String> securityGroups,
+                                             ScalableTarget scalableTarget) {
     ServerGroup.InstanceCounts instanceCounts = generateInstanceCount(instances);
 
-    return new EcsServerGroup()
-      .setDisabled(capacity.getDesired() < 1)     // TODO: Whether the server group is disabled should be determined by another factor.
+    EcsServerGroup serverGroup = new EcsServerGroup()
+      .setDisabled(capacity.getDesired() == 0)
       .setName(constructServerGroupName(metadata))
       .setCloudProvider(EcsCloudProvider.ID)
       .setType(EcsCloudProvider.ID)
@@ -261,8 +298,30 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
       .setTaskDefinition(taskDefinition)
       .setVpcId(vpcId)
       .setSecurityGroups(securityGroups)
-      .setAsg(new ApplicationAutoScalingGroup().setDesiredCapacity(1).setMaxSize(2).setMinSize(3))
       ;
+
+    if (scalableTarget != null) {
+      EcsServerGroup.AutoScalingGroup asg = new EcsServerGroup.AutoScalingGroup()
+        .setDesiredCapacity(scalableTarget.getMaxCapacity())
+        .setMaxSize(scalableTarget.getMaxCapacity())
+        .setMinSize(scalableTarget.getMinCapacity());
+
+      serverGroup.setAsg(asg);
+    }
+
+    return serverGroup;
+  }
+
+  private AWSApplicationAutoScaling getAmazonApplicationAutoScalingClient(AmazonCredentials credentials,
+                                                                          AmazonCredentials.AWSRegion awsRegion) {
+    String account = credentials.getName();
+    AWSCredentialsProvider provider = credentials.getCredentialsProvider();
+    String region = awsRegion.getName();
+    return amazonClientProvider.getAmazonApplicationAutoScaling(account, provider, region);
+  }
+
+  private String getServiceName(String serviceArn) {
+    return serviceArn.split("/")[1];
   }
 
   private ServerGroup.InstanceCounts generateInstanceCount(Set<Instance> instances) {


### PR DESCRIPTION
The EcsServerGroup class has been modified to contain a asg (Auto Scaling Group) field that represent the Scalable Target for ECS containers. This asg holds the information of the desired cluster size when the service is enabled.

If there is a related AutoScaling Group (Scalable Target)

/applications/\<application\>/serverGroups/\<account\>/\<region\>/\<service\>

will show:
```
{
  "asg" : {
    "desiredCapacity" : 1,
    "maxSize" : 1,
    "minSize" : 0
  },
  "capacity" : {
    "desired" : 1,
    "max" : 1,
    "min" : 0
  },
  "cloudProvider" : "ecs",
  ...
```

The CreateServerGroupAtomicOperation has been changed to record the desired size to the ECS scalable target on service creation

The ResizeServiceAtomicOperation has been updated to also modify the maximum capacity of the scalable target

Now Disable and EnableServiceAtomicOperation toggle the service between the 0 and the maximum capacity of the scalable target