### PR TITLE
Ecs cache container info

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
@@ -7,10 +7,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider.ID;
-import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICES;
 
 public class Keys implements KeyParser {
-  public static enum Namespace {
+  public enum Namespace {
     SERVICES,
     ECS_CLUSTERS,
     TASKS,
@@ -18,7 +17,7 @@ public class Keys implements KeyParser {
 
     final String ns;
 
-    private Namespace() {
+    Namespace() {
       ns = CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, this.name());
     }
 
@@ -89,7 +88,7 @@ public class Keys implements KeyParser {
   }
 
   public static String getServiceKey(String account, String region, String serviceName) {
-    return ID + SEPARATOR + SERVICES + SEPARATOR + account + SEPARATOR + region + SEPARATOR + serviceName;
+    return ID + SEPARATOR + Namespace.SERVICES + SEPARATOR + account + SEPARATOR + region + SEPARATOR + serviceName;
   }
 
   public static String getClusterKey(String account, String region, String clusterName) {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
@@ -7,9 +7,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider.ID;
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICES;
 
 public class Keys implements KeyParser {
-  public enum Namespace {
+  public static enum Namespace {
     SERVICES,
     ECS_CLUSTERS,
     TASKS,
@@ -35,6 +36,10 @@ public class Keys implements KeyParser {
 
   @Override
   public Map<String, String> parseKey(String key) {
+    return parse(key);
+  }
+
+  public static Map<String, String> parse(String key) {
     String[] parts = key.split(SEPARATOR);
 
     if (parts.length < 3 || !parts[0].equals(ID)) {
@@ -45,7 +50,7 @@ public class Keys implements KeyParser {
     result.put("provider", parts[0]);
     result.put("type", parts[1]);
 
-    switch (Namespace.valueOf(parts[1])) {
+    switch (Namespace.valueOf(CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, parts[1]))) {
       case SERVICES:
         result.put("account", parts[2]);
         result.put("region", parts[3]);
@@ -84,15 +89,19 @@ public class Keys implements KeyParser {
   }
 
   public static String getServiceKey(String account, String region, String serviceName) {
-    return ID + SEPARATOR + Namespace.SERVICES + SEPARATOR + account + SEPARATOR + region + SEPARATOR + serviceName;
+    return ID + SEPARATOR + SERVICES + SEPARATOR + account + SEPARATOR + region + SEPARATOR + serviceName;
   }
 
   public static String getClusterKey(String account, String region, String clusterName) {
     return ID + SEPARATOR + Namespace.ECS_CLUSTERS + SEPARATOR + account + SEPARATOR + region + SEPARATOR + clusterName;
   }
 
-  public static String getTaskKey(String account, String region, String taskArn) {
-    return ID + SEPARATOR + Namespace.TASKS + SEPARATOR + account + SEPARATOR + region + SEPARATOR + taskArn;
+  public static String getTaskKey(String account, String region, String taskId) {
+    return ID + SEPARATOR + Namespace.TASKS + SEPARATOR + account + SEPARATOR + region + SEPARATOR + taskId;
+  }
+
+  public static String getTaskHealthKey(String account, String region, String taslId) {
+    return ID + SEPARATOR + com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.HEALTH + SEPARATOR + account + SEPARATOR + region + SEPARATOR + taslId;
   }
 
   public static String getContainerInstanceKey(String account, String region, String containerInstanceArn) {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
@@ -92,7 +92,7 @@ public class Keys implements KeyParser {
   }
 
   public static String getTaskKey(String account, String region, String taskArn) {
-    return ID + SEPARATOR + Namespace.SERVICES + SEPARATOR + account + SEPARATOR + region + SEPARATOR + taskArn;
+    return ID + SEPARATOR + Namespace.TASKS + SEPARATOR + account + SEPARATOR + region + SEPARATOR + taskArn;
   }
 
   public static String getContainerInstanceKey(String account, String region, String containerInstanceArn) {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
@@ -91,8 +91,8 @@ public class Keys implements KeyParser {
     return ID + SEPARATOR + Namespace.ECS_CLUSTERS + SEPARATOR + account + SEPARATOR + region + SEPARATOR + clusterName;
   }
 
-  public static String getTaskKey(String account, String region, String taskName) {
-    return ID + SEPARATOR + Namespace.SERVICES + SEPARATOR + account + SEPARATOR + region + SEPARATOR + taskName;
+  public static String getTaskKey(String account, String region, String taskArn) {
+    return ID + SEPARATOR + Namespace.SERVICES + SEPARATOR + account + SEPARATOR + region + SEPARATOR + taskArn;
   }
 
   public static String getContainerInstanceKey(String account, String region, String containerInstanceArn) {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/TerminateInstancesAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/TerminateInstancesAtomicOperation.java
@@ -64,7 +64,6 @@ public class TerminateInstancesAtomicOperation implements AtomicOperation<Void> 
 
     for (String taskId: description.getEcsTaskIds()) {
       getTask().updateStatus(BASE_PHASE, "Terminating instance: " + taskId);
-      //TODO: Check if that the cache doesn't negatively impacts this atomic operation.
       String clusterArn = containerInformationService.getClusterArn(description.getCredentialAccount(), description.getRegion(), taskId);
       StopTaskRequest request = new StopTaskRequest().withTask(taskId).withCluster(clusterArn);
       ecs.stopTask(request);

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/TerminateInstancesAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/TerminateInstancesAtomicOperation.java
@@ -64,7 +64,8 @@ public class TerminateInstancesAtomicOperation implements AtomicOperation<Void> 
 
     for (String taskId: description.getEcsTaskIds()) {
       getTask().updateStatus(BASE_PHASE, "Terminating instance: " + taskId);
-      String clusterArn = containerInformationService.getClusterArn(ecs, taskId);
+      //TODO: Check if that the cache doesn't negatively impacts this atomic operation.
+      String clusterArn = containerInformationService.getClusterArn(description.getCredentialAccount(), description.getRegion(), taskId);
       StopTaskRequest request = new StopTaskRequest().withTask(taskId).withCluster(clusterArn);
       ecs.stopTask(request);
     }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/EcsProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/EcsProvider.java
@@ -3,6 +3,7 @@ package com.netflix.spinnaker.clouddriver.ecs.provider;
 import com.netflix.spinnaker.cats.agent.Agent;
 import com.netflix.spinnaker.cats.agent.AgentSchedulerAware;
 import com.netflix.spinnaker.clouddriver.cache.SearchableProvider;
+import com.netflix.spinnaker.clouddriver.core.provider.agent.HealthProvidingCachingAgent;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
 
@@ -11,11 +12,14 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLUSTERS;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.CONTAINER_INSTANCES;
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLUSTERS;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICES;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASKS;
 
@@ -30,11 +34,9 @@ public class EcsProvider extends AgentSchedulerAware implements SearchableProvid
   private static final Map<String, String> urlMappingTemplates = new HashMap<>();
 
   private final Collection<Agent> agents;
-
   private final AccountCredentialsRepository accountCredentialsRepository;
-
   private final Keys keys = new Keys();
-
+  private Collection<HealthProvidingCachingAgent> healthAgents;
 
   public EcsProvider(AccountCredentialsRepository accountCredentialsRepository, Collection<Agent> agents) {
     this.agents = agents;
@@ -70,6 +72,19 @@ public class EcsProvider extends AgentSchedulerAware implements SearchableProvid
   @Override
   public Collection<Agent> getAgents() {
     return agents;
+  }
+
+
+  public void synchronizeHealthAgents() {
+    this.healthAgents = Collections.unmodifiableCollection(agents.stream()
+      .filter(a -> a instanceof HealthProvidingCachingAgent)
+      .map(a -> (HealthProvidingCachingAgent) a).collect(Collectors.toList()));
+  }
+
+  public Collection<HealthProvidingCachingAgent> getHealthAgents() {
+    List<HealthProvidingCachingAgent> newHealthAgents = new LinkedList<>();
+    newHealthAgents.addAll(healthAgents);
+    return Collections.unmodifiableCollection(newHealthAgents);
   }
 
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/EcsProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/EcsProvider.java
@@ -76,7 +76,7 @@ public class EcsProvider extends AgentSchedulerAware implements SearchableProvid
 
 
   public void synchronizeHealthAgents() {
-    this.healthAgents = Collections.unmodifiableCollection(agents.stream()
+    healthAgents = Collections.unmodifiableCollection(agents.stream()
       .filter(a -> a instanceof HealthProvidingCachingAgent)
       .map(a -> (HealthProvidingCachingAgent) a).collect(Collectors.toList()));
   }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
@@ -1,0 +1,112 @@
+package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.ecs.AmazonECS;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.cats.agent.CacheResult;
+import com.netflix.spinnaker.cats.agent.CachingAgent;
+import com.netflix.spinnaker.cats.provider.ProviderCache;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent;
+import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport;
+import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
+import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
+import groovy.lang.Closure;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AbstractEcsCachingAgent<T> implements CachingAgent, OnDemandAgent {
+  protected AmazonClientProvider amazonClientProvider;
+  protected AWSCredentialsProvider awsCredentialsProvider;
+  protected String region;
+  protected String accountName;
+  protected OnDemandMetricsSupport metricsSupport;
+
+  public AbstractEcsCachingAgent(String accountName, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider, Registry registry) {
+    this.accountName = accountName;
+    this.region = region;
+    this.amazonClientProvider = amazonClientProvider;
+    this.awsCredentialsProvider = awsCredentialsProvider;
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, EcsCloudProvider.ID + ":" + EcsCloudProvider.ID + ":${OnDemandAgent.OnDemandType.ServerGroup}");
+  }
+
+  protected abstract List<T> getItems(AmazonECS ecs, ProviderCache providerCache);
+
+  protected abstract CacheResult buildCacheResult(List<T> items);
+
+  @Override
+  public String getProviderName() {
+    return EcsProvider.NAME;
+  }
+
+  @Override
+  public String getOnDemandAgentType() {
+    return getAgentType();
+  }
+
+  @Override
+  public OnDemandMetricsSupport getMetricsSupport() {
+    return metricsSupport;
+  }
+
+  @Override
+  public Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+    return new LinkedList<>();
+  }
+
+  @Override
+  public boolean handles(OnDemandType type, String cloudProvider) {
+    return type.equals(OnDemandType.ServerGroup) && cloudProvider.equals(EcsCloudProvider.ID);
+  }
+
+  @Override
+  public CacheResult loadData(ProviderCache providerCache) {
+    AmazonECS ecs = amazonClientProvider.getAmazonEcs(accountName, awsCredentialsProvider, region);
+    List<T> items = getItems(ecs, providerCache);
+    return buildCacheResult(items);
+  }
+
+  @Override
+  public OnDemandResult handle(ProviderCache providerCache, Map<String, ?> data) {
+    if (!data.get("account").equals(accountName) || !data.get("region").equals(region)) {
+      return null;
+    }
+
+    AmazonECS ecs = amazonClientProvider.getAmazonEcs(accountName, awsCredentialsProvider, region);
+
+    List<T> items = metricsSupport.readData(new Closure<List<T>>(this, this) {
+      public List<T> doCall() {
+        return getItems(ecs, providerCache);
+      }
+    });
+
+    storeOnDemand(providerCache, data);
+
+    CacheResult cacheResult = metricsSupport.transformData(new Closure<CacheResult>(this, this) {
+      public CacheResult doCall() {
+        return buildCacheResult(items);
+      }
+    });
+
+
+    Collection<String> typeStrings = new LinkedList<>();
+    for (AgentDataType agentDataType : getProvidedDataTypes()) {
+      typeStrings.add(agentDataType.toString());
+    }
+
+    OnDemandResult result = new OnDemandResult();
+    result.setAuthoritativeTypes(typeStrings);
+    result.setCacheResult(cacheResult);
+    result.setSourceAgentType(getAgentType());
+
+    return result;
+  }
+
+  protected void storeOnDemand(ProviderCache providerCache, Map<String, ?> data) {
+    //To be overwritten.
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
@@ -107,6 +107,6 @@ public abstract class AbstractEcsCachingAgent<T> implements CachingAgent, OnDema
   }
 
   protected void storeOnDemand(ProviderCache providerCache, Map<String, ?> data) {
-    //To be overwritten.
+    // TODO: Overwrite if needed.
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ClusterCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ClusterCachingAgent.java
@@ -15,6 +15,8 @@ import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
 import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -28,6 +30,8 @@ import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITA
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLUSTERS;
 
 public class ClusterCachingAgent implements CachingAgent {
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
   static final Collection<AgentDataType> types = Collections.unmodifiableCollection(Arrays.asList(
     AUTHORITATIVE.forType(ECS_CLUSTERS.toString())
   ));
@@ -74,6 +78,7 @@ public class ClusterCachingAgent implements CachingAgent {
       nextToken = listClustersResult.getNextToken();
     } while (nextToken != null && nextToken.length() != 0);
 
+    log.info("Caching " + dataPoints.size() + " instances in " + getAgentType());
     Map<String, Collection<CacheData>> dataMap = new HashMap<>();
     dataMap.put(ECS_CLUSTERS.toString(), dataPoints);
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ClusterCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ClusterCachingAgent.java
@@ -78,7 +78,7 @@ public class ClusterCachingAgent implements CachingAgent {
       nextToken = listClustersResult.getNextToken();
     } while (nextToken != null && nextToken.length() != 0);
 
-    log.info("Caching " + dataPoints.size() + " instances in " + getAgentType());
+    log.info("Caching " + dataPoints.size() + " clusters in " + getAgentType());
     Map<String, Collection<CacheData>> dataMap = new HashMap<>();
     dataMap.put(ECS_CLUSTERS.toString(), dataPoints);
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCachingAgent.java
@@ -56,7 +56,7 @@ public class ContainerInstanceCachingAgent implements CachingAgent {
     for (CacheData cluster : clusters) {
       String nextToken = null;
       do {
-        ListContainerInstancesRequest listContainerInstancesRequest = new ListContainerInstancesRequest().withCluster((String) cluster.getAttributes().get("name"));
+        ListContainerInstancesRequest listContainerInstancesRequest = new ListContainerInstancesRequest().withCluster((String) cluster.getAttributes().get("clusterName"));
         if (nextToken != null) {
           listContainerInstancesRequest.setNextToken(nextToken);
         }
@@ -65,7 +65,7 @@ public class ContainerInstanceCachingAgent implements CachingAgent {
         List<String> containerInstanceArns = listContainerInstancesResult.getContainerInstanceArns();
 
         List<ContainerInstance> containerInstances = ecs.describeContainerInstances(new DescribeContainerInstancesRequest()
-          .withCluster((String) cluster.getAttributes().get("name")).withContainerInstances(containerInstanceArns)).getContainerInstances();
+          .withCluster((String) cluster.getAttributes().get("clusterName")).withContainerInstances(containerInstanceArns)).getContainerInstances();
 
         for (ContainerInstance containerInstance : containerInstances) {
           Map<String, Object> attributes = new HashMap<>();

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCachingAgent.java
@@ -16,11 +16,7 @@ import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent;
-import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport;
-import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
-import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
-import groovy.lang.Closure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,69 +31,29 @@ import java.util.Map;
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.CONTAINER_INSTANCES;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLUSTERS;
-import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICES;
 
-public class ContainerInstanceCachingAgent implements CachingAgent, OnDemandAgent {
+public class ContainerInstanceCachingAgent extends AbstractEcsCachingAgent<ContainerInstance> implements CachingAgent, OnDemandAgent {
   static final Collection<AgentDataType> types = Collections.unmodifiableCollection(Arrays.asList(
     AUTHORITATIVE.forType(CONTAINER_INSTANCES.toString())
   ));
   private final Logger log = LoggerFactory.getLogger(getClass());
-  private AmazonClientProvider amazonClientProvider;
-  private AWSCredentialsProvider awsCredentialsProvider;
-  private String region;
-  private String accountName;
-  private OnDemandMetricsSupport metricsSupport;
 
   public ContainerInstanceCachingAgent(String accountName, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider, Registry registry) {
-    this.accountName = accountName;
-    this.region = region;
-    this.amazonClientProvider = amazonClientProvider;
-    this.awsCredentialsProvider = awsCredentialsProvider;
-    this.metricsSupport = new OnDemandMetricsSupport(registry, this, EcsCloudProvider.ID + ":" + EcsCloudProvider.ID + ":${OnDemandAgent.OnDemandType.ServerGroup}");
+    super(accountName, region, amazonClientProvider, awsCredentialsProvider, registry);
   }
 
   @Override
-  public CacheResult loadData(ProviderCache providerCache) {
-    AmazonECS ecs = amazonClientProvider.getAmazonEcs(accountName, awsCredentialsProvider, region);
-    List<ContainerInstance> containerInstances = getContainerInstances(ecs, providerCache);
-    return buildCacheResult(containerInstances);
+  public String getAgentType() {
+    return ServiceCachingAgent.class.getSimpleName();
   }
 
   @Override
-  public OnDemandResult handle(ProviderCache providerCache, Map<String, ?> data) {
-    if (!data.get("account").equals(accountName) || !data.get("region").equals(region)) {
-      return null;
-    }
-
-    AmazonECS ecs = amazonClientProvider.getAmazonEcs(accountName, awsCredentialsProvider, region);
-
-    List<ContainerInstance> containerInstances = metricsSupport.readData(new Closure<List<ContainerInstance>>(this, this) {
-      public List<ContainerInstance> doCall() {
-        return getContainerInstances(ecs, providerCache);
-      }
-    });
-
-    CacheResult cacheResult = metricsSupport.transformData(new Closure<CacheResult>(this, this) {
-      public CacheResult doCall() {
-        return buildCacheResult(containerInstances);
-      }
-    });
-
-
-    Collection<String> typeStrings = new LinkedList<>();
-    for (AgentDataType agentDataType : this.types) {
-      typeStrings.add(agentDataType.toString());
-    }
-
-    OnDemandResult result = new OnDemandResult();
-    result.setAuthoritativeTypes(typeStrings);
-    result.setCacheResult(cacheResult);
-    result.setSourceAgentType(getAgentType());
-
-    return result;
+  public Collection<AgentDataType> getProvidedDataTypes() {
+    return types;
   }
 
-  private List<ContainerInstance> getContainerInstances(AmazonECS ecs, ProviderCache providerCache) {
+  @Override
+  protected List<ContainerInstance> getItems(AmazonECS ecs, ProviderCache providerCache) {
     List<ContainerInstance> containerInstanceList = new LinkedList<>();
     Collection<CacheData> clusters = providerCache.getAll(ECS_CLUSTERS.toString());
 
@@ -125,7 +81,8 @@ public class ContainerInstanceCachingAgent implements CachingAgent, OnDemandAgen
     return containerInstanceList;
   }
 
-  private CacheResult buildCacheResult(List<ContainerInstance> containerInstances) {
+  @Override
+  protected CacheResult buildCacheResult(List<ContainerInstance> containerInstances) {
     Collection<CacheData> dataPoints = new LinkedList<>();
     for (ContainerInstance containerInstance : containerInstances) {
       Map<String, Object> attributes = new HashMap<>();
@@ -140,40 +97,5 @@ public class ContainerInstanceCachingAgent implements CachingAgent, OnDemandAgen
     Map<String, Collection<CacheData>> dataMap = new HashMap<>();
     dataMap.put(CONTAINER_INSTANCES.toString(), dataPoints);
     return new DefaultCacheResult(dataMap);
-  }
-
-  @Override
-  public String getAgentType() {
-    return ContainerInstanceCachingAgent.class.getSimpleName();
-  }
-
-  @Override
-  public String getProviderName() {
-    return EcsProvider.NAME;
-  }
-
-  @Override
-  public String getOnDemandAgentType() {
-    return getAgentType();
-  }
-
-  @Override
-  public OnDemandMetricsSupport getMetricsSupport() {
-    return metricsSupport;
-  }
-
-  @Override
-  public Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
-    return Collections.emptyList();
-  }
-
-  @Override
-  public boolean handles(OnDemandType type, String cloudProvider) {
-    return type.equals(OnDemandType.ServerGroup) && cloudProvider.equals(EcsCloudProvider.ID);
-  }
-
-  @Override
-  public Collection<AgentDataType> getProvidedDataTypes() {
-    return Collections.emptyList();
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCachingAgent.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.ecs.model.ContainerInstance;
 import com.amazonaws.services.ecs.model.DescribeContainerInstancesRequest;
 import com.amazonaws.services.ecs.model.ListContainerInstancesRequest;
 import com.amazonaws.services.ecs.model.ListContainerInstancesResult;
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
 import com.netflix.spinnaker.cats.agent.CacheResult;
 import com.netflix.spinnaker.cats.agent.CachingAgent;
@@ -14,8 +15,12 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent;
+import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport;
+import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
+import groovy.lang.Closure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,31 +35,70 @@ import java.util.Map;
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.CONTAINER_INSTANCES;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLUSTERS;
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICES;
 
-public class ContainerInstanceCachingAgent implements CachingAgent {
-  private final Logger log = LoggerFactory.getLogger(getClass());
-
+public class ContainerInstanceCachingAgent implements CachingAgent, OnDemandAgent {
   static final Collection<AgentDataType> types = Collections.unmodifiableCollection(Arrays.asList(
     AUTHORITATIVE.forType(CONTAINER_INSTANCES.toString())
   ));
-
+  private final Logger log = LoggerFactory.getLogger(getClass());
   private AmazonClientProvider amazonClientProvider;
   private AWSCredentialsProvider awsCredentialsProvider;
   private String region;
   private String accountName;
+  private OnDemandMetricsSupport metricsSupport;
 
-  public ContainerInstanceCachingAgent(String accountName, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider) {
+  public ContainerInstanceCachingAgent(String accountName, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider, Registry registry) {
     this.accountName = accountName;
     this.region = region;
     this.amazonClientProvider = amazonClientProvider;
     this.awsCredentialsProvider = awsCredentialsProvider;
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, EcsCloudProvider.ID + ":" + EcsCloudProvider.ID + ":${OnDemandAgent.OnDemandType.ServerGroup}");
   }
 
   @Override
   public CacheResult loadData(ProviderCache providerCache) {
     AmazonECS ecs = amazonClientProvider.getAmazonEcs(accountName, awsCredentialsProvider, region);
+    List<ContainerInstance> containerInstances = getContainerInstances(ecs, providerCache);
+    return buildCacheResult(containerInstances);
+  }
 
-    Collection<CacheData> dataPoints = new LinkedList<>();
+  @Override
+  public OnDemandResult handle(ProviderCache providerCache, Map<String, ?> data) {
+    if (!data.get("account").equals(accountName) || !data.get("region").equals(region)) {
+      return null;
+    }
+
+    AmazonECS ecs = amazonClientProvider.getAmazonEcs(accountName, awsCredentialsProvider, region);
+
+    List<ContainerInstance> containerInstances = metricsSupport.readData(new Closure<List<ContainerInstance>>(this, this) {
+      public List<ContainerInstance> doCall() {
+        return getContainerInstances(ecs, providerCache);
+      }
+    });
+
+    CacheResult cacheResult = metricsSupport.transformData(new Closure<CacheResult>(this, this) {
+      public CacheResult doCall() {
+        return buildCacheResult(containerInstances);
+      }
+    });
+
+
+    Collection<String> typeStrings = new LinkedList<>();
+    for (AgentDataType agentDataType : this.types) {
+      typeStrings.add(agentDataType.toString());
+    }
+
+    OnDemandResult result = new OnDemandResult();
+    result.setAuthoritativeTypes(typeStrings);
+    result.setCacheResult(cacheResult);
+    result.setSourceAgentType(getAgentType());
+
+    return result;
+  }
+
+  private List<ContainerInstance> getContainerInstances(AmazonECS ecs, ProviderCache providerCache) {
+    List<ContainerInstance> containerInstanceList = new LinkedList<>();
     Collection<CacheData> clusters = providerCache.getAll(ECS_CLUSTERS.toString());
 
     for (CacheData cluster : clusters) {
@@ -67,27 +111,34 @@ public class ContainerInstanceCachingAgent implements CachingAgent {
 
         ListContainerInstancesResult listContainerInstancesResult = ecs.listContainerInstances(listContainerInstancesRequest);
         List<String> containerInstanceArns = listContainerInstancesResult.getContainerInstanceArns();
+        if (containerInstanceArns.size() == 0) {
+          continue;
+        }
 
         List<ContainerInstance> containerInstances = ecs.describeContainerInstances(new DescribeContainerInstancesRequest()
           .withCluster((String) cluster.getAttributes().get("clusterName")).withContainerInstances(containerInstanceArns)).getContainerInstances();
-
-        for (ContainerInstance containerInstance : containerInstances) {
-          Map<String, Object> attributes = new HashMap<>();
-          attributes.put("containerInstanceArn", containerInstance.getContainerInstanceArn());
-          attributes.put("ec2InstanceId", containerInstance.getEc2InstanceId());
-
-          String key = Keys.getContainerInstanceKey(accountName, region, containerInstance.getContainerInstanceArn());
-          dataPoints.add(new DefaultCacheData(key, attributes, Collections.emptyMap()));
-        }
+        containerInstanceList.addAll(containerInstances);
 
         nextToken = listContainerInstancesResult.getNextToken();
       } while (nextToken != null && nextToken.length() != 0);
     }
+    return containerInstanceList;
+  }
 
-    log.info("Caching " + dataPoints.size() + " instances in " + getAgentType());
+  private CacheResult buildCacheResult(List<ContainerInstance> containerInstances) {
+    Collection<CacheData> dataPoints = new LinkedList<>();
+    for (ContainerInstance containerInstance : containerInstances) {
+      Map<String, Object> attributes = new HashMap<>();
+      attributes.put("containerInstanceArn", containerInstance.getContainerInstanceArn());
+      attributes.put("ec2InstanceId", containerInstance.getEc2InstanceId());
+
+      String key = Keys.getContainerInstanceKey(accountName, region, containerInstance.getContainerInstanceArn());
+      dataPoints.add(new DefaultCacheData(key, attributes, Collections.emptyMap()));
+    }
+
+    log.info("Caching " + dataPoints.size() + " container instances in " + getAgentType());
     Map<String, Collection<CacheData>> dataMap = new HashMap<>();
     dataMap.put(CONTAINER_INSTANCES.toString(), dataPoints);
-
     return new DefaultCacheResult(dataMap);
   }
 
@@ -102,7 +153,27 @@ public class ContainerInstanceCachingAgent implements CachingAgent {
   }
 
   @Override
+  public String getOnDemandAgentType() {
+    return getAgentType();
+  }
+
+  @Override
+  public OnDemandMetricsSupport getMetricsSupport() {
+    return metricsSupport;
+  }
+
+  @Override
+  public Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public boolean handles(OnDemandType type, String cloudProvider) {
+    return type.equals(OnDemandType.ServerGroup) && cloudProvider.equals(EcsCloudProvider.ID);
+  }
+
+  @Override
   public Collection<AgentDataType> getProvidedDataTypes() {
-    return types;
+    return Collections.emptyList();
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCachingAgent.java
@@ -16,6 +16,8 @@ import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -30,6 +32,8 @@ import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.CONTAIN
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLUSTERS;
 
 public class ContainerInstanceCachingAgent implements CachingAgent {
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
   static final Collection<AgentDataType> types = Collections.unmodifiableCollection(Arrays.asList(
     AUTHORITATIVE.forType(CONTAINER_INSTANCES.toString())
   ));
@@ -80,6 +84,7 @@ public class ContainerInstanceCachingAgent implements CachingAgent {
       } while (nextToken != null && nextToken.length() != 0);
     }
 
+    log.info("Caching " + dataPoints.size() + " instances in " + getAgentType());
     Map<String, Collection<CacheData>> dataMap = new HashMap<>();
     dataMap.put(CONTAINER_INSTANCES.toString(), dataPoints);
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsClusterCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsClusterCachingAgent.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLUSTERS;
 
-public class ClusterCachingAgent implements CachingAgent {
+public class EcsClusterCachingAgent implements CachingAgent {
   private final Logger log = LoggerFactory.getLogger(getClass());
 
   static final Collection<AgentDataType> types = Collections.unmodifiableCollection(Arrays.asList(
@@ -41,7 +41,7 @@ public class ClusterCachingAgent implements CachingAgent {
   private String region;
   private String accountName;
 
-  public ClusterCachingAgent(String accountName, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider) {
+  public EcsClusterCachingAgent(String accountName, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider) {
     this.accountName = accountName;
     this.region = region;
     this.amazonClientProvider = amazonClientProvider;
@@ -78,7 +78,7 @@ public class ClusterCachingAgent implements CachingAgent {
       nextToken = listClustersResult.getNextToken();
     } while (nextToken != null && nextToken.length() != 0);
 
-    log.info("Caching " + dataPoints.size() + " clusters in " + getAgentType());
+    log.info("Caching " + dataPoints.size() + " ECS clusters in " + getAgentType());
     Map<String, Collection<CacheData>> dataMap = new HashMap<>();
     dataMap.put(ECS_CLUSTERS.toString(), dataPoints);
 
@@ -87,7 +87,7 @@ public class ClusterCachingAgent implements CachingAgent {
 
   @Override
   public String getAgentType() {
-    return ClusterCachingAgent.class.getSimpleName();
+    return EcsClusterCachingAgent.class.getSimpleName();
   }
 
   @Override

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCachingAgent.java
@@ -57,13 +57,13 @@ public class ServiceCachingAgent implements CachingAgent {
     for (CacheData cluster : clusters) {
       String nextToken = null;
       do {
-        ListServicesRequest listServicesRequest = new ListServicesRequest().withCluster((String) cluster.getAttributes().get("name"));
+        ListServicesRequest listServicesRequest = new ListServicesRequest().withCluster((String) cluster.getAttributes().get("clusterName"));
         if (nextToken != null) {
           listServicesRequest.setNextToken(nextToken);
         }
         ListServicesResult listServicesResult = ecs.listServices(listServicesRequest);
         List<String> serviceArns = listServicesResult.getServiceArns();
-        List<Service> services = ecs.describeServices(new DescribeServicesRequest().withCluster((String) cluster.getAttributes().get("name")).withServices(serviceArns)).getServices();
+        List<Service> services = ecs.describeServices(new DescribeServicesRequest().withCluster((String) cluster.getAttributes().get("clusterName")).withServices(serviceArns)).getServices();
 
         for (Service service : services) {
           Map<String, Object> attributes = new HashMap<>();

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCachingAgent.java
@@ -68,9 +68,12 @@ public class ServiceCachingAgent implements CachingAgent {
         for (Service service : services) {
           Map<String, Object> attributes = new HashMap<>();
           String applicationName = service.getServiceName().contains("-") ? StringUtils.substringBefore(service.getServiceName(), "-") : service.getServiceName();
+          String clusterName = StringUtils.substringAfterLast(service.getClusterArn(), "/");
+
           attributes.put("applicationName", applicationName);
           attributes.put("serviceName", service.getServiceName());
           attributes.put("serviceArn", service.getServiceArn());
+          attributes.put("clusterName", clusterName);
           attributes.put("clusterArn", service.getClusterArn());
           attributes.put("roleArn", service.getRoleArn());
           attributes.put("taskDefinition", service.getTaskDefinition());

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCachingAgent.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.ecs.model.DescribeServicesRequest;
 import com.amazonaws.services.ecs.model.ListServicesRequest;
 import com.amazonaws.services.ecs.model.ListServicesResult;
 import com.amazonaws.services.ecs.model.Service;
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
 import com.netflix.spinnaker.cats.agent.CacheResult;
 import com.netflix.spinnaker.cats.agent.CachingAgent;
@@ -14,8 +15,12 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent;
+import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport;
+import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
+import groovy.lang.Closure;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,29 +37,68 @@ import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITA
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLUSTERS;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICES;
 
-public class ServiceCachingAgent implements CachingAgent {
-  private final Logger log = LoggerFactory.getLogger(getClass());
-
+public class ServiceCachingAgent implements CachingAgent, OnDemandAgent {
   static final Collection<AgentDataType> types = Collections.unmodifiableCollection(Arrays.asList(
     AUTHORITATIVE.forType(SERVICES.toString())
   ));
+  private final Logger log = LoggerFactory.getLogger(getClass());
   private AmazonClientProvider amazonClientProvider;
   private AWSCredentialsProvider awsCredentialsProvider;
   private String region;
   private String accountName;
+  private OnDemandMetricsSupport metricsSupport;
 
-  public ServiceCachingAgent(String accountName, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider) {
+  public ServiceCachingAgent(String accountName, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider, Registry registry) {
     this.accountName = accountName;
     this.region = region;
     this.amazonClientProvider = amazonClientProvider;
     this.awsCredentialsProvider = awsCredentialsProvider;
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, EcsCloudProvider.ID + ":" + EcsCloudProvider.ID + ":${OnDemandAgent.OnDemandType.ServerGroup}");
   }
 
   @Override
   public CacheResult loadData(ProviderCache providerCache) {
     AmazonECS ecs = amazonClientProvider.getAmazonEcs(accountName, awsCredentialsProvider, region);
+    List<Service> services = getServices(ecs, providerCache);
+    return buildCacheResult(services);
+  }
 
-    Collection<CacheData> dataPoints = new LinkedList<>();
+  @Override
+  public OnDemandResult handle(ProviderCache providerCache, Map<String, ?> data) {
+    if (!data.get("account").equals(accountName) || !data.get("region").equals(region)) {
+      return null;
+    }
+
+    AmazonECS ecs = amazonClientProvider.getAmazonEcs(accountName, awsCredentialsProvider, region);
+
+    List<Service> services = metricsSupport.readData(new Closure<List<Service>>(this, this) {
+      public List<Service> doCall() {
+        return getServices(ecs, providerCache);
+      }
+    });
+
+    CacheResult cacheResult = metricsSupport.transformData(new Closure<CacheResult>(this, this) {
+      public CacheResult doCall() {
+        return buildCacheResult(services);
+      }
+    });
+
+
+    Collection<String> typeStrings = new LinkedList<>();
+    for (AgentDataType agentDataType : this.types) {
+      typeStrings.add(agentDataType.toString());
+    }
+
+    OnDemandResult result = new OnDemandResult();
+    result.setAuthoritativeTypes(typeStrings);
+    result.setCacheResult(cacheResult);
+    result.setSourceAgentType(getAgentType());
+
+    return result;
+  }
+
+  private List<Service> getServices(AmazonECS ecs, ProviderCache providerCache) {
+    List<Service> serviceList = new LinkedList<>();
     Collection<CacheData> clusters = providerCache.getAll(ECS_CLUSTERS.toString());
 
     for (CacheData cluster : clusters) {
@@ -66,37 +110,46 @@ public class ServiceCachingAgent implements CachingAgent {
         }
         ListServicesResult listServicesResult = ecs.listServices(listServicesRequest);
         List<String> serviceArns = listServicesResult.getServiceArns();
-        List<Service> services = ecs.describeServices(new DescribeServicesRequest().withCluster((String) cluster.getAttributes().get("clusterName")).withServices(serviceArns)).getServices();
-
-        for (Service service : services) {
-          Map<String, Object> attributes = new HashMap<>();
-          String applicationName = service.getServiceName().contains("-") ? StringUtils.substringBefore(service.getServiceName(), "-") : service.getServiceName();
-          String clusterName = StringUtils.substringAfterLast(service.getClusterArn(), "/");
-
-          attributes.put("applicationName", applicationName);
-          attributes.put("serviceName", service.getServiceName());
-          attributes.put("serviceArn", service.getServiceArn());
-          attributes.put("clusterName", clusterName);
-          attributes.put("clusterArn", service.getClusterArn());
-          attributes.put("roleArn", service.getRoleArn());
-          attributes.put("taskDefinition", service.getTaskDefinition());
-          attributes.put("desiredCount", service.getDesiredCount());
-          attributes.put("maximumPercent", service.getDeploymentConfiguration().getMaximumPercent());
-          attributes.put("minimumHealthyPercent", service.getDeploymentConfiguration().getMinimumHealthyPercent());
-          attributes.put("loadBalancers", service.getLoadBalancers());
-
-
-          String key = Keys.getServiceKey(accountName, region, service.getServiceName());
-          dataPoints.add(new DefaultCacheData(key, attributes, Collections.emptyMap()));
+        if (serviceArns.size() == 0) {
+          continue;
         }
+
+        List<Service> services = ecs.describeServices(new DescribeServicesRequest().withCluster((String) cluster.getAttributes().get("clusterName")).withServices(serviceArns)).getServices();
+        serviceList.addAll(services);
+
         nextToken = listServicesResult.getNextToken();
       } while (nextToken != null && nextToken.length() != 0);
     }
+    return serviceList;
+  }
 
-    log.info("Caching " + dataPoints.size() + " instances in " + getAgentType());
+  private CacheResult buildCacheResult(List<Service> services) {
+    Collection<CacheData> dataPoints = new LinkedList<>();
+    for (Service service : services) {
+      Map<String, Object> attributes = new HashMap<>();
+      String applicationName = service.getServiceName().contains("-") ? StringUtils.substringBefore(service.getServiceName(), "-") : service.getServiceName();
+      String clusterName = StringUtils.substringAfterLast(service.getClusterArn(), "/");
+
+      attributes.put("applicationName", applicationName);
+      attributes.put("serviceName", service.getServiceName());
+      attributes.put("serviceArn", service.getServiceArn());
+      attributes.put("clusterName", clusterName);
+      attributes.put("clusterArn", service.getClusterArn());
+      attributes.put("roleArn", service.getRoleArn());
+      attributes.put("taskDefinition", service.getTaskDefinition());
+      attributes.put("desiredCount", service.getDesiredCount());
+      attributes.put("maximumPercent", service.getDeploymentConfiguration().getMaximumPercent());
+      attributes.put("minimumHealthyPercent", service.getDeploymentConfiguration().getMinimumHealthyPercent());
+      attributes.put("loadBalancers", service.getLoadBalancers());
+
+
+      String key = Keys.getServiceKey(accountName, region, service.getServiceName());
+      dataPoints.add(new DefaultCacheData(key, attributes, Collections.emptyMap()));
+    }
+
+    log.info("Caching " + dataPoints.size() + " services in " + getAgentType());
     Map<String, Collection<CacheData>> dataMap = new HashMap<>();
     dataMap.put(SERVICES.toString(), dataPoints);
-
     return new DefaultCacheResult(dataMap);
   }
 
@@ -108,6 +161,26 @@ public class ServiceCachingAgent implements CachingAgent {
   @Override
   public String getProviderName() {
     return EcsProvider.NAME;
+  }
+
+  @Override
+  public String getOnDemandAgentType() {
+    return getAgentType();
+  }
+
+  @Override
+  public OnDemandMetricsSupport getMetricsSupport() {
+    return metricsSupport;
+  }
+
+  @Override
+  public Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public boolean handles(OnDemandType type, String cloudProvider) {
+    return type.equals(OnDemandType.ServerGroup) && cloudProvider.equals(EcsCloudProvider.ID);
   }
 
   @Override

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCachingAgent.java
@@ -17,6 +17,8 @@ import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -31,10 +33,11 @@ import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLU
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICES;
 
 public class ServiceCachingAgent implements CachingAgent {
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
   static final Collection<AgentDataType> types = Collections.unmodifiableCollection(Arrays.asList(
     AUTHORITATIVE.forType(SERVICES.toString())
   ));
-
   private AmazonClientProvider amazonClientProvider;
   private AWSCredentialsProvider awsCredentialsProvider;
   private String region;
@@ -90,6 +93,7 @@ public class ServiceCachingAgent implements CachingAgent {
       } while (nextToken != null && nextToken.length() != 0);
     }
 
+    log.info("Caching " + dataPoints.size() + " instances in " + getAgentType());
     Map<String, Collection<CacheData>> dataMap = new HashMap<>();
     dataMap.put(SERVICES.toString(), dataPoints);
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.ecs.model.DescribeTasksRequest;
 import com.amazonaws.services.ecs.model.ListTasksRequest;
 import com.amazonaws.services.ecs.model.ListTasksResult;
 import com.amazonaws.services.ecs.model.Task;
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
 import com.netflix.spinnaker.cats.agent.CacheResult;
 import com.netflix.spinnaker.cats.agent.CachingAgent;
@@ -14,8 +15,12 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent;
+import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport;
+import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
+import groovy.lang.Closure;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,32 +28,35 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.ON_DEMAND;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLUSTERS;
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICES;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASKS;
 
-public class TaskCachingAgent implements CachingAgent {
-  private final Logger log = LoggerFactory.getLogger(getClass());
-
+public class TaskCachingAgent implements CachingAgent, OnDemandAgent {
   static final Collection<AgentDataType> types = Collections.unmodifiableCollection(Arrays.asList(
     AUTHORITATIVE.forType(TASKS.toString())
   ));
-
+  private final Logger log = LoggerFactory.getLogger(getClass());
   private AmazonClientProvider amazonClientProvider;
   private AWSCredentialsProvider awsCredentialsProvider;
   private String region;
   private String accountName;
+  private OnDemandMetricsSupport metricsSupport;
 
-  public TaskCachingAgent(String accountName, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider) {
+  public TaskCachingAgent(String accountName, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider, Registry registry) {
     this.accountName = accountName;
     this.region = region;
     this.amazonClientProvider = amazonClientProvider;
     this.awsCredentialsProvider = awsCredentialsProvider;
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, EcsCloudProvider.ID + ":" + EcsCloudProvider.ID + ":${OnDemandAgent.OnDemandType.ServerGroup}");
   }
 
   @Override
@@ -59,8 +67,62 @@ public class TaskCachingAgent implements CachingAgent {
   @Override
   public CacheResult loadData(ProviderCache providerCache) {
     AmazonECS ecs = amazonClientProvider.getAmazonEcs(accountName, awsCredentialsProvider, region);
+    List<Task> tasks = getTasks(ecs, providerCache);
+    CacheResult cacheResult = buildCacheResult(tasks);
 
-    Collection<CacheData> dataPoints = new LinkedList<>();
+    /*for(CacheData data: cacheResult.getCacheResults().get(ON_DEMAND.toString())){
+      data.getAttributes().put("processedTime", System.currentTimeMillis());
+      data.getAttributes().put("processedCount", (data.getAttributes().get("processedCount") == null ? (Integer)data.getAttributes().get("processedCount") : 0) + 1);
+    }*/
+
+    return cacheResult;
+  }
+
+  @Override
+  public OnDemandResult handle(ProviderCache providerCache, Map<String, ?> data) {
+    if (!data.get("account").equals(accountName) || !data.get("region").equals(region)) {
+      return null;
+    }
+
+    AmazonECS ecs = amazonClientProvider.getAmazonEcs(accountName, awsCredentialsProvider, region);
+
+    List<Task> tasks = metricsSupport.readData(new Closure<List<Task>>(this, this) {
+      public List<Task> doCall() {
+        return getTasks(ecs, providerCache);
+      }
+    });
+
+    metricsSupport.onDemandStore(new Closure<List<Task>>(this, this) {
+      public void doCall() {
+        String keyString = Keys.getServiceKey(accountName, region, (String) data.get("serverGroupName"));
+        Map<String, Object> att = new HashMap<>();
+        att.put("cacheTime", new Date());
+        CacheData cacheData = new DefaultCacheData(keyString, att, Collections.emptyMap());
+        providerCache.putCacheData(ON_DEMAND.toString(), cacheData);
+      }
+    });
+
+    CacheResult cacheResult = metricsSupport.transformData(new Closure<CacheResult>(this, this) {
+      public CacheResult doCall() {
+        return buildCacheResult(tasks);
+      }
+    });
+
+    Collection<String> typeStrings = new LinkedList<>();
+    for (AgentDataType agentDataType : this.types) {
+      typeStrings.add(agentDataType.toString());
+    }
+
+    OnDemandResult result = new OnDemandResult();
+    result.setAuthoritativeTypes(typeStrings);
+    result.setCacheResult(cacheResult);
+    result.setSourceAgentType(getAgentType());
+
+    return result;
+  }
+
+  private List<Task> getTasks(AmazonECS ecs, ProviderCache providerCache) {
+    List<Task> taskList = new LinkedList<>();
     Collection<CacheData> clusters = providerCache.getAll(ECS_CLUSTERS.toString());
 
     for (CacheData cluster : clusters) {
@@ -72,25 +134,36 @@ public class TaskCachingAgent implements CachingAgent {
         }
         ListTasksResult listTasksResult = ecs.listTasks(listTasksRequest);
         List<String> taskArns = listTasksResult.getTaskArns();
-        List<Task> tasks = ecs.describeTasks(new DescribeTasksRequest().withCluster((String) cluster.getAttributes().get("clusterName")).withTasks(taskArns)).getTasks();
-
-        for (Task task : tasks) {
-          String taskId = StringUtils.substringAfterLast(task.getTaskArn(), "/");
-          Map<String, Object> attributes = new HashMap<>();
-          attributes.put("taskId", taskId);
-          attributes.put("taskArn", task.getTaskArn());
-          attributes.put("clusterArn", task.getClusterArn());
-          attributes.put("containerInstanceArn", task.getContainerInstanceArn());
-          attributes.put("containers", task.getContainers());
-
-          String key = Keys.getTaskKey(accountName, region, taskId);
-          dataPoints.add(new DefaultCacheData(key, attributes, Collections.emptyMap()));
+        if (taskArns.size() == 0) {
+          continue;
         }
+        List<Task> tasks = ecs.describeTasks(new DescribeTasksRequest().withCluster((String) cluster.getAttributes().get("clusterName")).withTasks(taskArns)).getTasks();
+        taskList.addAll(tasks);
         nextToken = listTasksResult.getNextToken();
       } while (nextToken != null && nextToken.length() != 0);
     }
+    return taskList;
+  }
 
-    log.info("Caching " + dataPoints.size() + " instances in " + getAgentType());
+  private CacheResult buildCacheResult(List<Task> tasks) {
+    Collection<CacheData> dataPoints = new LinkedList<>();
+    for (Task task : tasks) {
+      String taskId = StringUtils.substringAfterLast(task.getTaskArn(), "/");
+      Map<String, Object> attributes = new HashMap<>();
+      attributes.put("taskId", taskId);
+      attributes.put("taskArn", task.getTaskArn());
+      attributes.put("clusterArn", task.getClusterArn());
+      attributes.put("containerInstanceArn", task.getContainerInstanceArn());
+      attributes.put("group", task.getGroup());
+      attributes.put("containers", task.getContainers());
+      attributes.put("lastStatus", task.getLastStatus());
+      attributes.put("desiredStatus", task.getDesiredStatus());
+
+      String key = Keys.getTaskKey(accountName, region, taskId);
+      dataPoints.add(new DefaultCacheData(key, attributes, Collections.emptyMap()));
+    }
+
+    log.info("Caching " + dataPoints.size() + " tasks in " + getAgentType());
     Map<String, Collection<CacheData>> dataMap = new HashMap<>();
     dataMap.put(TASKS.toString(), dataPoints);
 
@@ -105,5 +178,45 @@ public class TaskCachingAgent implements CachingAgent {
   @Override
   public String getProviderName() {
     return EcsProvider.NAME;
+  }
+
+  @Override
+  public String getOnDemandAgentType() {
+    return getAgentType();
+  }
+
+  @Override
+  public OnDemandMetricsSupport getMetricsSupport() {
+    return metricsSupport;
+  }
+
+  @Override
+  public Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+    Collection<CacheData> allOnDemand = providerCache.getAll(ON_DEMAND.toString());
+    List<Map> returnResults = new LinkedList<>();
+    for(CacheData onDemand:allOnDemand){
+      Map<String, String> parsedKey = Keys.parse(onDemand.getId());
+      if(parsedKey.get("type")!=null && (parsedKey.get("type").equals(SERVICES.toString()) || parsedKey.get("type").equals(TASKS.toString()))){
+        parsedKey.put("type", "serverGroup");
+        parsedKey.put("serverGroup", parsedKey.get("serviceName"));
+
+        HashMap<String, Object> result = new HashMap<>();
+        result.put("id", onDemand.getId());
+        result.put("details", parsedKey);
+
+        result.put("cacheTime", onDemand.getAttributes().get("cacheTime"));
+        result.put("cacheExpiry", onDemand.getAttributes().get("cacheExpiry"));
+        result.put("processedCount", (onDemand.getAttributes().get("processedCount") != null ? onDemand.getAttributes().get("processedCount") : 1));
+        result.put("processedTime", onDemand.getAttributes().get("processedTime") !=null ? onDemand.getAttributes().get("processedTime") : new Date());
+
+        returnResults.add(result);
+      }
+    }
+    return returnResults;
+  }
+
+  @Override
+  public boolean handles(OnDemandType type, String cloudProvider) {
+    return type.equals(OnDemandType.ServerGroup) && cloudProvider.equals(EcsCloudProvider.ID);
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
@@ -62,13 +62,13 @@ public class TaskCachingAgent implements CachingAgent {
     for (CacheData cluster : clusters) {
       String nextToken = null;
       do {
-        ListTasksRequest listTasksRequest = new ListTasksRequest().withCluster((String) cluster.getAttributes().get("name"));
+        ListTasksRequest listTasksRequest = new ListTasksRequest().withCluster((String) cluster.getAttributes().get("clusterName"));
         if (nextToken != null) {
           listTasksRequest.setNextToken(nextToken);
         }
         ListTasksResult listTasksResult = ecs.listTasks(listTasksRequest);
         List<String> taskArns = listTasksResult.getTaskArns();
-        List<Task> tasks = ecs.describeTasks(new DescribeTasksRequest().withCluster((String) cluster.getAttributes().get("name")).withTasks(taskArns)).getTasks();
+        List<Task> tasks = ecs.describeTasks(new DescribeTasksRequest().withCluster((String) cluster.getAttributes().get("clusterName")).withTasks(taskArns)).getTasks();
 
         for (Task task : tasks) {
           Map<String, Object> attributes = new HashMap<>();
@@ -77,7 +77,7 @@ public class TaskCachingAgent implements CachingAgent {
           attributes.put("containerInstanceArn", task.getContainerInstanceArn());
           attributes.put("containers", task.getContainers());
 
-          String key = Keys.getTaskKey(accountName, region, task.getContainerInstanceArn());
+          String key = Keys.getTaskKey(accountName, region, task.getTaskArn());
           dataPoints.add(new DefaultCacheData(key, attributes, Collections.emptyMap()));
         }
         nextToken = listTasksResult.getNextToken();

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
@@ -1,0 +1,140 @@
+package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.ecs.AmazonECS;
+import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing;
+import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetHealthRequest;
+import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetHealthResult;
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetDescription;
+import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.cats.agent.CacheResult;
+import com.netflix.spinnaker.cats.agent.CachingAgent;
+import com.netflix.spinnaker.cats.agent.DefaultCacheResult;
+import com.netflix.spinnaker.cats.cache.CacheData;
+import com.netflix.spinnaker.cats.cache.DefaultCacheData;
+import com.netflix.spinnaker.cats.provider.ProviderCache;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.core.provider.agent.HealthProvidingCachingAgent;
+import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
+import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.HEALTH;
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.CONTAINER_INSTANCES;
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICES;
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASKS;
+
+public class TaskHealthCachingAgent implements CachingAgent, HealthProvidingCachingAgent {
+  static final Collection<AgentDataType> types = Collections.unmodifiableCollection(Arrays.asList(
+    AUTHORITATIVE.forType(HEALTH.toString())
+  ));
+  private final static String HEALTH_ID = "ecs-task-instance-health";
+  private final Logger log = LoggerFactory.getLogger(getClass());
+  private AmazonClientProvider amazonClientProvider;
+  private AWSCredentialsProvider awsCredentialsProvider;
+  private String region;
+  private String accountName;
+
+  public TaskHealthCachingAgent(String accountName, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider) {
+    this.accountName = accountName;
+    this.region = region;
+    this.amazonClientProvider = amazonClientProvider;
+    this.awsCredentialsProvider = awsCredentialsProvider;
+  }
+
+  @Override
+  public Collection<AgentDataType> getProvidedDataTypes() {
+    return types;
+  }
+
+  @Override
+  public CacheResult loadData(ProviderCache providerCache) {
+    AmazonECS ecs = amazonClientProvider.getAmazonEcs(accountName, awsCredentialsProvider, region);
+    AmazonElasticLoadBalancing amazonloadBalancing = amazonClientProvider.getAmazonElasticLoadBalancingV2(accountName, awsCredentialsProvider, region);
+
+    Collection<CacheData> dataPoints = new LinkedList<>();
+    Collection<String> taskEvicitions = new LinkedList<>();
+
+    Collection<CacheData> tasksCache = providerCache.getAll(TASKS.toString());
+    if(tasksCache != null ) {
+      for (CacheData taskCache : tasksCache) {
+        String containerInstanceCacheKey = Keys.getContainerInstanceKey(accountName, region, (String) taskCache.getAttributes().get("containerInstanceArn"));
+        CacheData containerInstance = providerCache.get(CONTAINER_INSTANCES.toString(), containerInstanceCacheKey);
+
+        String serviceName = StringUtils.substringAfter((String) taskCache.getAttributes().get("group"), "service:");
+        String serviceCacheKey = Keys.getServiceKey(accountName, region, serviceName);
+        CacheData serviceCache = providerCache.get(SERVICES.toString(), serviceCacheKey);
+        if (serviceCache == null || containerInstance == null) {
+          taskEvicitions.add(taskCache.getId());
+          continue;
+        }
+
+        int port = 0;
+        try {
+          port = (Integer) ((List<Map<String, Object>>) ((List<Map<String, Object>>) taskCache.getAttributes().get("containers")).get(0).get("networkBindings")).get(0).get("hostPort");
+        } catch (NullPointerException e) {
+          e.printStackTrace();
+        }
+
+        List<Map<String, Object>> loadBalancers = new LinkedList<>();
+        try {
+          loadBalancers = (List<Map<String, Object>>) serviceCache.getAttributes().get("loadBalancers");
+        } catch (NullPointerException e) {
+          e.printStackTrace();
+        }
+        for (Map<String, Object> loadBalancer : loadBalancers) {
+          DescribeTargetHealthResult describeTargetHealthResult = amazonloadBalancing.describeTargetHealth(
+            new DescribeTargetHealthRequest().withTargetGroupArn((String) loadBalancer.get("targetGroupArn")).withTargets(
+              new TargetDescription().withId((String) containerInstance.getAttributes().get("ec2InstanceId")).withPort(port)));
+
+          Map<String, Object> attributes = new HashMap<>();
+          attributes.put("instanceId", (String) taskCache.getAttributes().get("taskArn"));
+
+          String targetHealth = describeTargetHealthResult.getTargetHealthDescriptions().get(0).getTargetHealth().getState();
+
+          attributes.put("state", targetHealth.equals("healthy") ? "Up" : "Unknown");  // TODO - Return better values, and think of a better strategy at defining health
+          attributes.put("type", "loadBalancer");
+
+          String key = Keys.getTaskHealthKey(accountName, region, (String) taskCache.getAttributes().get("taskId"));
+          dataPoints.add(new DefaultCacheData(key, attributes, Collections.emptyMap()));
+        }
+      }
+    }
+
+    log.info("Caching " + dataPoints.size() + " task health checks in " + getAgentType());
+    Map<String, Collection<CacheData>> dataMap = new HashMap<>();
+    dataMap.put(HEALTH.toString(), dataPoints);
+
+    log.info("Evicting " + taskEvicitions.size() + " task health checks in " + getAgentType());
+    Map<String, Collection<String>> evictionMap = new HashMap<>();
+    evictionMap.put(TASKS.toString(), taskEvicitions);
+
+    return new DefaultCacheResult(dataMap, evictionMap);
+  }
+
+  @Override
+  public String getAgentType() {
+    return TaskHealthCachingAgent.class.getSimpleName();
+  }
+
+  @Override
+  public String getProviderName() {
+    return EcsProvider.NAME;
+  }
+
+  @Override
+  public String getHealthId() {
+    return HEALTH_ID;
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/config/EcsProviderConfig.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/config/EcsProviderConfig.java
@@ -6,7 +6,7 @@ import com.netflix.spinnaker.cats.agent.Agent;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
-import com.netflix.spinnaker.clouddriver.ecs.provider.agent.ClusterCachingAgent;
+import com.netflix.spinnaker.clouddriver.ecs.provider.agent.EcsClusterCachingAgent;
 import com.netflix.spinnaker.clouddriver.ecs.provider.agent.ContainerInstanceCachingAgent;
 import com.netflix.spinnaker.clouddriver.ecs.provider.agent.ServiceCachingAgent;
 import com.netflix.spinnaker.clouddriver.ecs.provider.agent.TaskCachingAgent;
@@ -52,7 +52,7 @@ public class EcsProviderConfig {
       if (credentials.getCloudProvider().equals("ecs")) {
         for (AWSRegion region : credentials.getRegions()) {
           if (!scheduledAccounts.contains(credentials.getName())) {
-            newAgents.add(new ClusterCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider));
+            newAgents.add(new EcsClusterCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider));
             newAgents.add(new ServiceCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider, registry));
             newAgents.add(new TaskCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider, registry));
             newAgents.add(new ContainerInstanceCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider, registry));

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/config/EcsProviderConfig.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/config/EcsProviderConfig.java
@@ -1,14 +1,16 @@
 package com.netflix.spinnaker.clouddriver.ecs.provider.config;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.Agent;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
-import com.netflix.spinnaker.clouddriver.ecs.provider.agent.ServiceCachingAgent;
 import com.netflix.spinnaker.clouddriver.ecs.provider.agent.ClusterCachingAgent;
-import com.netflix.spinnaker.clouddriver.ecs.provider.agent.TaskCachingAgent;
 import com.netflix.spinnaker.clouddriver.ecs.provider.agent.ContainerInstanceCachingAgent;
+import com.netflix.spinnaker.clouddriver.ecs.provider.agent.ServiceCachingAgent;
+import com.netflix.spinnaker.clouddriver.ecs.provider.agent.TaskCachingAgent;
+import com.netflix.spinnaker.clouddriver.ecs.provider.agent.TaskHealthCachingAgent;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
 import com.netflix.spinnaker.clouddriver.security.ProviderUtils;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -31,35 +33,37 @@ import static com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials.A
 public class EcsProviderConfig {
   @Bean
   @DependsOn("netflixECSCredentials")
-  public EcsProvider ecsProvider(AccountCredentialsRepository accountCredentialsRepository, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider) {
+  public EcsProvider ecsProvider(AccountCredentialsRepository accountCredentialsRepository, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider, Registry registry) {
     EcsProvider provider = new EcsProvider(accountCredentialsRepository, Collections.newSetFromMap(new ConcurrentHashMap<Agent, Boolean>()));
-    synchronizeEcsProvider(provider, accountCredentialsRepository, amazonClientProvider, awsCredentialsProvider);
+    synchronizeEcsProvider(provider, accountCredentialsRepository, amazonClientProvider, awsCredentialsProvider, registry);
     return provider;
   }
 
   @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
   @Bean
   public EcsProviderSynchronizer synchronizeEcsProvider(EcsProvider ecsProvider, AccountCredentialsRepository accountCredentialsRepository,
-                                                        AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider) {
+                                                        AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider, Registry registry) {
 
     Set<String> scheduledAccounts = ProviderUtils.getScheduledAccounts(ecsProvider);
     Set<NetflixAmazonCredentials> allAccounts = ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, NetflixAmazonCredentials.class);
     List<Agent> newAgents = new LinkedList<>();
 
     for (NetflixAmazonCredentials credentials : allAccounts) {
-      if(credentials.getCloudProvider().equals("ecs")) {
+      if (credentials.getCloudProvider().equals("ecs")) {
         for (AWSRegion region : credentials.getRegions()) {
           if (!scheduledAccounts.contains(credentials.getName())) {
-            newAgents.add(new ClusterCachingAgent(credentials.getName(),region.getName(),amazonClientProvider, awsCredentialsProvider));
-            newAgents.add(new ServiceCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider));
-            newAgents.add(new TaskCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider));
-            newAgents.add(new ContainerInstanceCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider));
+            newAgents.add(new ClusterCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider));
+            newAgents.add(new ServiceCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider, registry));
+            newAgents.add(new TaskCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider, registry));
+            newAgents.add(new ContainerInstanceCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider, registry));
+            newAgents.add(new TaskHealthCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider));
           }
         }
       }
     }
 
     ecsProvider.getAgents().addAll(newAgents);
+    ecsProvider.synchronizeHealthAgents();
     return new EcsProviderSynchronizer();
   }
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
@@ -139,16 +139,19 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
 
           for (Task task : describeTasksResult.getTasks()) {
             InstanceStatus ec2InstanceStatus = containerInformationService.getEC2InstanceStatus(
-              amazonEC2, credentials.getName(), awsRegion.getName(),
-              containerInformationService.getContainerInstanceArn(credentials.getName(), awsRegion.getName(), task));
+              amazonEC2, credentials.getName(), awsRegion.getName(), task.getContainerInstanceArn());
 
             String address = containerInformationService.getTaskPrivateAddress(credentials.getName(), awsRegion.getName(), amazonEC2, task);
 
             List<Map<String, String>> healthStatus = containerInformationService.getHealthStatus(clusterArn, task.getTaskArn(), serviceArn, credentials.getName(), "us-west-2");
-            instances.add(new EcsTask(extractTaskIdFromTaskArn(task.getTaskArn()), task, ec2InstanceStatus, healthStatus, address));
+            try {
+              instances.add(new EcsTask(extractTaskIdFromTaskArn(task.getTaskArn()), task, ec2InstanceStatus, healthStatus, address));
+            }catch(NullPointerException e){
+              e.printStackTrace();
+            }
 
             if (vpcId == null) {
-              String es2HostId = containerInformationService.getEC2InstanceHostID(credentials.getName(), awsRegion.getName(),containerInformationService.getContainerInstanceArn(credentials.getName(), awsRegion.getName(), task));
+              String es2HostId = containerInformationService.getEC2InstanceHostID(credentials.getName(), awsRegion.getName(), task.getContainerInstanceArn());
               com.amazonaws.services.ec2.model.Instance oneEc2Instance = amazonEC2.describeInstances(new DescribeInstancesRequest().withInstanceIds(es2HostId)).getReservations().get(0).getInstances().get(0);
               vpcId = oneEc2Instance.getVpcId();
               for (GroupIdentifier groupIdentifier: oneEc2Instance.getSecurityGroups()) {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
@@ -143,7 +143,7 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
 
             String address = containerInformationService.getTaskPrivateAddress(credentials.getName(), awsRegion.getName(), amazonEC2, task);
 
-            List<Map<String, String>> healthStatus = containerInformationService.getHealthStatus(clusterArn, task.getTaskArn(), serviceArn, credentials.getName(), "us-west-2");
+            List<Map<String, String>> healthStatus = containerInformationService.getHealthStatus(task.getTaskArn(), serviceArn, credentials.getName(), "us-west-2");
             try {
               instances.add(new EcsTask(extractTaskIdFromTaskArn(task.getTaskArn()), task, ec2InstanceStatus, healthStatus, address));
             }catch(NullPointerException e){

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
@@ -139,16 +139,17 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
 
           for (Task task : describeTasksResult.getTasks()) {
             InstanceStatus ec2InstanceStatus = containerInformationService.getEC2InstanceStatus(
-              amazonEC2,
-              containerInformationService.getContainerInstance(amazonECS, task));
+              amazonEC2, credentials.getName(), awsRegion.getName(),
+              containerInformationService.getContainerInstanceArn(credentials.getName(), awsRegion.getName(), task));
 
-            String address = containerInformationService.getTaskPrivateAddress(amazonECS, amazonEC2, task);
+            String address = containerInformationService.getTaskPrivateAddress(credentials.getName(), awsRegion.getName(), amazonEC2, task);
 
             List<Map<String, String>> healthStatus = containerInformationService.getHealthStatus(clusterArn, task.getTaskArn(), serviceArn, credentials.getName(), "us-west-2");
             instances.add(new EcsTask(extractTaskIdFromTaskArn(task.getTaskArn()), task, ec2InstanceStatus, healthStatus, address));
 
             if (vpcId == null) {
-              com.amazonaws.services.ec2.model.Instance oneEc2Instance = amazonEC2.describeInstances(new DescribeInstancesRequest().withInstanceIds(containerInformationService.getContainerInstance(amazonECS, task).getEc2InstanceId())).getReservations().get(0).getInstances().get(0);
+              String es2HostId = containerInformationService.getEC2InstanceHostID(credentials.getName(), awsRegion.getName(),containerInformationService.getContainerInstanceArn(credentials.getName(), awsRegion.getName(), task));
+              com.amazonaws.services.ec2.model.Instance oneEc2Instance = amazonEC2.describeInstances(new DescribeInstancesRequest().withInstanceIds(es2HostId)).getReservations().get(0).getInstances().get(0);
               vpcId = oneEc2Instance.getVpcId();
               for (GroupIdentifier groupIdentifier: oneEc2Instance.getSecurityGroups()) {
                 securityGroups.add(groupIdentifier.getGroupId());

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsInstanceProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsInstanceProvider.java
@@ -56,11 +56,11 @@ public class EcsInstanceProvider implements InstanceProvider<EcsTask> {
     AmazonEC2 amazonEC2 = amazonClientProvider.getAmazonEC2(account, awsCredentialsProvider, region);
 
     Task ecsTask = getTask(amazonECS, id);
-    InstanceStatus instanceStatus = containerInformationService.getEC2InstanceStatus(amazonEC2, containerInformationService.getContainerInstance(amazonECS, ecsTask));
+    InstanceStatus instanceStatus = containerInformationService.getEC2InstanceStatus(amazonEC2, account, region, containerInformationService.getContainerInstanceArn(account, region, ecsTask));
 
     if (ecsTask != null && instanceStatus != null) {
 //      List<Map<String, String>> healthStatus = containerInformationService.getHealthStatus("poc", ecsTask.getTaskArn(), null, "continuous-delivery", "us-west-2");  // TODO - Use the caching system properly
-      String address = containerInformationService.getTaskPrivateAddress(amazonECS, amazonEC2, ecsTask);
+      String address = containerInformationService.getTaskPrivateAddress(account, region, amazonEC2, ecsTask);
       ecsInstance = new EcsTask(id, ecsTask, instanceStatus, null, address);
     }
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsInstanceProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsInstanceProvider.java
@@ -56,7 +56,7 @@ public class EcsInstanceProvider implements InstanceProvider<EcsTask> {
     AmazonEC2 amazonEC2 = amazonClientProvider.getAmazonEC2(account, awsCredentialsProvider, region);
 
     Task ecsTask = getTask(amazonECS, id);
-    InstanceStatus instanceStatus = containerInformationService.getEC2InstanceStatus(amazonEC2, account, region, containerInformationService.getContainerInstanceArn(account, region, ecsTask));
+    InstanceStatus instanceStatus = containerInformationService.getEC2InstanceStatus(amazonEC2, account, region, ecsTask.getContainerInstanceArn());
 
     if (ecsTask != null && instanceStatus != null) {
 //      List<Map<String, String>> healthStatus = containerInformationService.getHealthStatus("poc", ecsTask.getTaskArn(), null, "continuous-delivery", "us-west-2");  // TODO - Use the caching system properly


### PR DESCRIPTION
Created a TaskHealthCachingAgent.
ContainerInstanceService now uses the cache in its' methods.
Task/Service/ContainerInstance CachingAgents extend AbstractEcsCachingAgent.
getContainerInstanceArn removed from ContainerInstanceService.
EcsServerClusterProvider and EcsInstanceProvider modified to use the modfied ContainerInstanceService methods.
Fixes in Keys.


@BrunoCarrier 