### PR TITLE
Disable reporting the asg in the server group description. 

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
@@ -317,7 +317,8 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
         .setMaxSize(scalableTarget.getMaxCapacity())
         .setMinSize(scalableTarget.getMinCapacity());
 
-      serverGroup.setAsg(asg);
+      // TODO: Update Deck to handle an asg. Current Deck implementation uses a EC2 AutoScaling Group
+      //serverGroup.setAsg(asg);
     }
 
     return serverGroup;


### PR DESCRIPTION
Disable reporting the asg in the server group description. 

It causes the Server Group modal to crash. We need to modify Deck to handle ECS autoscaling groups for Server Groups (Services)