### PR TITLE
Ecs cache instance provider

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/EcsTask.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/EcsTask.java
@@ -38,13 +38,13 @@ public class EcsTask implements Instance, Serializable {
   private String cloudProvider;
   private String privateAddress;
 
-  public EcsTask(String name, Task task, InstanceStatus ec2Instance, List<Map<String, String>> health, String privateAddress) {
+  public EcsTask(String name, Long launchTime, String lastStatus, String desiredStatus, String availabilityZone, List<Map<String, String>> health, String privateAddress) {
     this.name = name;
     providerType = cloudProvider = EcsCloudProvider.ID;
-    launchTime = task.getStartedAt() != null ? task.getStartedAt().getTime() : null;
+    this.launchTime = launchTime;//task.getStartedAt() != null ? task.getStartedAt().getTime() : null;
     this.health =  health;
-    healthState = calculateHealthState(task.getLastStatus(), task.getDesiredStatus());
-    zone = ec2Instance.getAvailabilityZone();
+    healthState = calculateHealthState(lastStatus, desiredStatus);
+    zone = availabilityZone;
     this.privateAddress = privateAddress;
   }
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
@@ -91,9 +91,11 @@ public class TaskCachingAgent extends AbstractEcsCachingAgent<Task> {
       attributes.put("clusterArn", task.getClusterArn());
       attributes.put("containerInstanceArn", task.getContainerInstanceArn());
       attributes.put("group", task.getGroup());
+      //TODO: consider making containers a flat structure, if it cannot be deserialized.
       attributes.put("containers", task.getContainers());
       attributes.put("lastStatus", task.getLastStatus());
       attributes.put("desiredStatus", task.getDesiredStatus());
+      attributes.put("startedAt", task.getStartedAt());
 
       String key = Keys.getTaskKey(accountName, region, taskId);
       dataPoints.add(new DefaultCacheData(key, attributes, Collections.emptyMap()));

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsInstanceProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsInstanceProvider.java
@@ -26,20 +26,18 @@ import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASKS;
 @Component
 public class EcsInstanceProvider implements InstanceProvider<EcsTask> {
 
+  private AccountCredentialsProvider accountCredentialsProvider;
+  private AmazonClientProvider amazonClientProvider;
+  private ContainerInformationService containerInformationService;
   private final Cache cacheView;
 
   @Autowired
-  private AccountCredentialsProvider accountCredentialsProvider;
-
-  @Autowired
-  private AmazonClientProvider amazonClientProvider;
-
-  @Autowired
-  private ContainerInformationService containerInformationService;
-
-  @Autowired
-  public EcsInstanceProvider(Cache cacheView) {
+  public EcsInstanceProvider(Cache cacheView, AccountCredentialsProvider accountCredentialsProvider,
+                             AmazonClientProvider amazonClientProvider, ContainerInformationService containerInformationService) {
     this.cacheView = cacheView;
+    this.accountCredentialsProvider = accountCredentialsProvider;
+    this.amazonClientProvider = amazonClientProvider;
+    this.containerInformationService = containerInformationService;
   }
 
   @Override

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsInstanceProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsInstanceProvider.java
@@ -3,30 +3,30 @@ package com.netflix.spinnaker.clouddriver.ecs.view;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.model.InstanceStatus;
-import com.amazonaws.services.ecs.AmazonECS;
-import com.amazonaws.services.ecs.model.DescribeTasksRequest;
-import com.amazonaws.services.ecs.model.InvalidParameterException;
-import com.amazonaws.services.ecs.model.ListClustersRequest;
-import com.amazonaws.services.ecs.model.ListClustersResult;
-import com.amazonaws.services.ecs.model.Task;
+import com.netflix.spinnaker.cats.cache.Cache;
+import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
-import com.netflix.spinnaker.clouddriver.ecs.services.ContainerInformationService;
+import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.model.EcsTask;
+import com.netflix.spinnaker.clouddriver.ecs.services.ContainerInformationService;
 import com.netflix.spinnaker.clouddriver.model.InstanceProvider;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASKS;
 
 
 @Component
 public class EcsInstanceProvider implements InstanceProvider<EcsTask> {
 
-  private final String cloudProvider = EcsCloudProvider.ID;
+  private final Cache cacheView;
 
   @Autowired
   private AccountCredentialsProvider accountCredentialsProvider;
@@ -37,9 +37,14 @@ public class EcsInstanceProvider implements InstanceProvider<EcsTask> {
   @Autowired
   private ContainerInformationService containerInformationService;
 
+  @Autowired
+  public EcsInstanceProvider(Cache cacheView) {
+    this.cacheView = cacheView;
+  }
+
   @Override
   public String getCloudProvider() {
-    return cloudProvider;
+    return EcsCloudProvider.ID;
   }
 
   @Override
@@ -52,16 +57,32 @@ public class EcsInstanceProvider implements InstanceProvider<EcsTask> {
     NetflixAmazonCredentials netflixAmazonCredentials =
       (NetflixAmazonCredentials) accountCredentialsProvider.getCredentials(account);
     AWSCredentialsProvider awsCredentialsProvider = netflixAmazonCredentials.getCredentialsProvider();
-    AmazonECS amazonECS = amazonClientProvider.getAmazonEcs(account, awsCredentialsProvider, region);
     AmazonEC2 amazonEC2 = amazonClientProvider.getAmazonEC2(account, awsCredentialsProvider, region);
 
-    Task ecsTask = getTask(amazonECS, id);
-    InstanceStatus instanceStatus = containerInformationService.getEC2InstanceStatus(amazonEC2, account, region, ecsTask.getContainerInstanceArn());
+    String key = Keys.getTaskKey(account, region, id);
+    CacheData taskCache = cacheView.get(TASKS.toString(), key);
+    if (taskCache == null) {
+      return null;
+    }
 
-    if (ecsTask != null && instanceStatus != null) {
-//      List<Map<String, String>> healthStatus = containerInformationService.getHealthStatus("poc", ecsTask.getTaskArn(), null, "continuous-delivery", "us-west-2");  // TODO - Use the caching system properly
-      String address = containerInformationService.getTaskPrivateAddress(account, region, amazonEC2, ecsTask);
-      ecsInstance = new EcsTask(id, ecsTask, instanceStatus, null, address);
+    //TODO: getEC2InstanceStatus is only being made to determine the availability zone of the instance.
+    InstanceStatus instanceStatus = containerInformationService.getEC2InstanceStatus(amazonEC2, account, region, (String) taskCache.getAttributes().get("containerInstanceArn"));
+
+    if (instanceStatus != null) {
+      String serviceName = StringUtils.substringAfter((String) taskCache.getAttributes().get("group"), "service:");
+      List<Map<String, String>> healthStatus = containerInformationService.getHealthStatus(id, serviceName, account, region);
+
+      //TODO: This hostPort can be cleaned up after EcsServerClusterProvider starts using the cache.
+      int hostPort;
+      try {
+        hostPort = (Integer) ((List<Map<String, Object>>) ((List<Map<String, Object>>) taskCache.getAttributes().get("containers")).get(0).get("networkBindings")).get(0).get("hostPort");
+      } catch (NullPointerException e) {
+        hostPort = -1;
+      }
+
+      String address = containerInformationService.getTaskPrivateAddress(account, region, amazonEC2, hostPort, (String) taskCache.getAttributes().get("containerInstanceArn"));
+      Long launchTime = (Long) taskCache.getAttributes().get("startedAt");
+      ecsInstance = new EcsTask(id, launchTime, (String) taskCache.getAttributes().get("lastStatus"), (String) taskCache.getAttributes().get("desiredStatus"), instanceStatus.getAvailabilityZone(), healthStatus, address);
     }
 
     return ecsInstance;
@@ -72,46 +93,11 @@ public class EcsInstanceProvider implements InstanceProvider<EcsTask> {
     return null;
   }
 
-  private List<String> getAllClusters(AmazonECS amazonECS) {
-    ListClustersResult listClustersResult = amazonECS.listClusters();
-    List<String> clusterList = listClustersResult.getClusterArns();
-    while (listClustersResult.getNextToken() != null) {
-      listClustersResult = amazonECS.listClusters(
-        new ListClustersRequest().withNextToken(listClustersResult.getNextToken())
-      );
-      clusterList.addAll(listClustersResult.getClusterArns());
-    }
-    return clusterList;
-  }
-
   private boolean isValidId(String id, String region) {
     String id_regex = "[\\da-f]{8}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{12}";
     String id_only = String.format("^%s$", id_regex);
     String arn = String.format("arn:aws:ecs:%s:\\d*:task/%s", region, id_regex);
     return id.matches(id_only) || id.matches(arn);
-  }
-
-  private Task getTask(AmazonECS amazonECS, String taskId) {
-    Task task = null;
-
-    List<String> queryList = new ArrayList<>();
-    queryList.add(taskId);
-
-    for (String cluster: getAllClusters(amazonECS)) {
-      DescribeTasksRequest request = new DescribeTasksRequest()
-        .withCluster(cluster)
-        .withTasks(queryList);
-      List<Task> taskList = amazonECS.describeTasks(request).getTasks();
-      if (!taskList.isEmpty()) {
-        if (taskList.size() != 1) {
-          String message = String.format("Task ID: %s should only match one record. Multiple found.", taskId);
-          throw new InvalidParameterException(message);
-        }
-        task = taskList.get(0);
-        break;
-      }
-    }
-    return task;
   }
 
 }


### PR DESCRIPTION
EcsInstanceProvider reworked to use the cache.
EcsTask takes in generic objects instead of a Task.
startedAt attribute for task is now cached.
ContainerInformationService getHealthStatus now takes in taskId instead of taskArn.
ContainerInformationService getTaskPrivateAddress now takes in hostPort and containArn instead of Task.
EcsServerClusterProvider modified to use new ContainerInformationService methods.

@BrunoCarrier 