### PR TITLE
CreateServerGroup AO region fix.

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/AbstractEcsAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/AbstractEcsAtomicOperation.java
@@ -51,16 +51,20 @@ public abstract class AbstractEcsAtomicOperation<T extends AbstractECSDescriptio
   }
 
   String getCluster(String service, String account) {
-    String region = description.getRegion();
+    String region = getRegion();
     return containerInformationService.getClusterName(service, account, region);
   }
 
   AmazonECS getAmazonEcsClient() {
     AWSCredentialsProvider credentialsProvider = getCredentials().getCredentialsProvider();
-    String region = description.getRegion();
+    String region = getRegion();
     String credentialAccount = description.getCredentialAccount();
 
     return amazonClientProvider.getAmazonEcs(credentialAccount, credentialsProvider, region);
+  }
+
+  protected String getRegion(){
+    return description.getRegion();
   }
 
   AmazonCredentials getCredentials() {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
@@ -299,7 +299,9 @@ public class CreateServerGroupAtomicOperation extends AbstractEcsAtomicOperation
     return getFamilyName() + "-" + versionString;
   }
 
-  private String getRegion() {
+  @Override
+  protected String getRegion() {
+    //CreateServerGroupDescription does not contain a region. Instead it has AvailabilityZones
     return description.getAvailabilityZones().keySet().iterator().next();
   }
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
@@ -98,7 +98,8 @@ abstract class AbstractEcsCachingAgent<T> implements CachingAgent {
    */
   Set<String> getClusters(AmazonECS ecs, ProviderCache providerCache) {
     Set<String> clusters = providerCache.getAll(ECS_CLUSTERS.toString()).stream()
-      .filter(cacheData ->  cacheData.getAttributes().get("region").equals(region))
+      .filter(cacheData ->  cacheData.getAttributes().get("region").equals(region) &&
+                            cacheData.getAttributes().get("account").equals(accountName))
       .map(cacheData -> (String) cacheData.getAttributes().get("clusterArn"))
       .collect(Collectors.toSet());
 


### PR DESCRIPTION
`AbstractEcsAtomicOperations` gets the region from description by default, or a method can be overriden.

`CreateServerGroup` AO overrides this method, and provides the region based on the passed in availability zone in the description - since it's description does not have a region but an AZ instead.

@BrunoCarrier 